### PR TITLE
set desktopName for Wayland app_id to display correct icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "main": "index.mjs",
   "type": "module",
+  "desktopName": "notion-electron.desktop",
   "scripts": {
     "postinstall": "electron-builder install-app-deps",
     "start": "APPIMAGE=/ electron .",


### PR DESCRIPTION
## Issue
On Wayland (KDE Plasma, GNOME), notion-electron displays the generic icon when notion-electron is started.
<img width="187" height="141" alt="image" src="https://github.com/user-attachments/assets/5c849e03-2aaf-4dce-ba62-5bb0f5ee4a7c" />


This is because Electron wasn't setting the correct Wayland app_id, which desktop environments use to match windows to their .desktop files for icon lookup.

## Solution
Add desktopName to the desktop app's package.json. Electron uses this field to set the XDG app_id on Linux, allowing the window manager to match the application to notion-electron.desktop and display the correct icon.