### PR TITLE
Refactor shortcuts structure and implement standard browser function keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Notes.md
 package/
 build/
 .flatpak-builder/
+.vscode/
+result

--- a/lib/shortcuts/action.mjs
+++ b/lib/shortcuts/action.mjs
@@ -1,4 +1,4 @@
-export const shortcutMap = {
+export const actionKeymap = {
 	zoomIn: {
 		accelerator: 'CmdOrCtrl+=',
 		action: ({ pageWebContents, titlebarWebContents }) => {
@@ -78,26 +78,3 @@ export const shortcutMap = {
 		},
 	},
 };
-
-function toTitleCase(str) {
-	return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
-}
-
-export function detectShortcut(input, event, pageWebContents, titlebarWebContents) {
-	const accelerator = [];
-	if (input.control) accelerator.push('CmdOrCtrl');
-	if (input.shift) accelerator.push('Shift');
-	if (input.alt) accelerator.push('Alt');
-	if (input.meta) accelerator.push('Meta');
-	accelerator.push(input.key.length === 1 ? toTitleCase(input.key) : input.key);
-	const accelString = accelerator.join('+');
-
-	const shortcut = Object.values(shortcutMap).find(s => s.accelerator === accelString);
-	if (shortcut) {
-		shortcut.action({
-			pageWebContents,
-			titlebarWebContents,
-		});
-		event.preventDefault();
-	}
-}

--- a/lib/shortcuts/functional.mjs
+++ b/lib/shortcuts/functional.mjs
@@ -1,0 +1,62 @@
+import { BrowserWindow, shell } from 'electron';
+
+export const functionalKeymap = {
+	openHelpF1: {
+		accelerator: 'F1',
+		action: () => {
+			// Opens Notion's official help center in the user's default native web browser
+			shell.openExternal('https://www.notion.so/help');
+		},
+	},
+	findInPageF3: {
+		accelerator: 'F3',
+		action: ({ pageWebContents }) => {
+			if (!pageWebContents) return;
+			pageWebContents.focus();
+			// Notion usually handles F3 natively, but if it's being blocked,
+			// you can manually trigger the internal find dialog:
+			pageWebContents.sendInputEvent({
+				type: 'keyDown',
+				keyCode: 'f',
+				modifiers: ['control'],
+			});
+		},
+	},
+
+	// F4: Focus Address Bar (Skipped: No address bar in this wrapper)
+
+	pageReloadF5: {
+		accelerator: 'F5',
+		action: ({ pageWebContents }) => {
+			if (!pageWebContents) return;
+			pageWebContents.reloadIgnoringCache();
+		},
+	},
+
+	// F6: Cycle Focus (Skipped: No toolbars to cycle through)
+	// F7: Caret Browsing (Skipped: Requires heavy custom DOM manipulation in Electron)
+	// F8: Pause Debugger (Skipped: Handled natively when DevTools is open)
+	// F9: Reader Mode (Skipped: Not applicable to Notion)
+	// F10: Focus Menu Bar (Skipped: App menu is disabled in index.mjs)
+
+	toggleFullScreenF11: {
+		accelerator: 'F11',
+		action: ({ pageWebContents, titlebarWebContents }) => {
+			const contents = pageWebContents || titlebarWebContents;
+			if (!contents) return;
+
+			const win = BrowserWindow.fromWebContents(contents);
+			if (win) {
+				win.setFullScreen(!win.isFullScreen());
+			}
+		},
+	},
+
+	openDevToolsF12: {
+		accelerator: 'F12',
+		action: ({ pageWebContents }) => {
+			if (!pageWebContents) return;
+			pageWebContents.toggleDevTools();
+		},
+	},
+};

--- a/lib/shortcuts/index.mjs
+++ b/lib/shortcuts/index.mjs
@@ -1,0 +1,26 @@
+import { functionalKeymap } from './functional.mjs';
+import { actionKeymap } from './action.mjs';
+
+function toTitleCase(str) {
+	return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+}
+
+export const shortcutMap = { ...functionalKeymap, ...actionKeymap };
+
+export function detectShortcut(input, event, pageWebContents, titlebarWebContents) {
+	const accelerator = [];
+	if (input.control) accelerator.push('CmdOrCtrl');
+	if (input.shift) accelerator.push('Shift');
+	if (input.alt) accelerator.push('Alt');
+	if (input.meta) accelerator.push('Meta');
+	accelerator.push(input.key.length === 1 ? toTitleCase(input.key) : input.key);
+	const accelString = accelerator.join('+');
+	const shortcut = Object.values(shortcutMap).find(s => s.accelerator === accelString);
+	if (shortcut) {
+		shortcut.action({
+			pageWebContents,
+			titlebarWebContents,
+		});
+		event.preventDefault();
+	}
+}

--- a/services/contextMenu.mjs
+++ b/services/contextMenu.mjs
@@ -8,7 +8,7 @@ import {
 } from "electron";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { shortcutMap } from "../lib/shortcuts.mjs";
+import { shortcutMap } from '../lib/shortcuts/index.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/services/tabs.mjs
+++ b/services/tabs.mjs
@@ -2,7 +2,7 @@ import { WebContentsView, ipcMain, shell, app } from "electron";
 import { URL, fileURLToPath } from "node:url";
 import path from "node:path";
 import { convertIcon } from "../lib/image.mjs";
-import { detectShortcut, shortcutMap } from "../lib/shortcuts.mjs";
+import { detectShortcut, shortcutMap } from "../lib/shortcuts/index.mjs";
 import pkg from "../package.json" with { type: "json" };
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Summary
This PR restructures the shortcuts module for better maintainability and introduces standard web browser functional key behaviors to improve the native desktop experience.

## Changes Made

Refactored File Structure: Moved lib/shortcuts.mjs into a dedicated lib/shortcuts/ directory, splitting the logic into index.mjs, action.mjs, and functional.mjs for cleaner separation of concerns.

Added Standard Function Keys (F1-F12): Implemented a new functionalKeymap to map standard browser expectations to the Electron 

- F1: Opens the official Notion Help Center in the default web browser.
- F3: Triggers "Find in Page" (via Ctrl+F 
- F5: Reloads the current page (ignoring cache).
- F11: Toggles native fullscreen mode.
- F12: Toggles Developer Tools.
  (Note: Irrelevant keys like F4, F6, F9, etc., are explicitly skipped and documented to prevent future confusion and to leave room to specify other usafe for it).