### PR TITLE
Fix WebContentsView layout after window maximize and snap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2279,9 +2279,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5878,9 +5878,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "flatpak-clean": "./dev/flatpak/clean.sh",
     "snap-build": "./dev/snap/build.sh",
     "snap-upload": "snapcraft upload --release=stable \"$(find dist -maxdepth 1 -type f -name '*.snap')\"",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "Artem Nechunaev <artem@nechunaev.com>",

--- a/services/tabs.mjs
+++ b/services/tabs.mjs
@@ -3,11 +3,11 @@ import { URL, fileURLToPath } from "node:url";
 import path from "node:path";
 import { convertIcon } from "../lib/image.mjs";
 import { detectShortcut, shortcutMap } from "../lib/shortcuts/index.mjs";
+import { getTabViewLayout } from "./viewLayout.mjs";
 import pkg from "../package.json" with { type: "json" };
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const TITLEBAR_HEIGHT = 40;
 const HOME_PAGE = "https://www.notion.com/login";
 const CALENDAR_PAGE = "https://calendar.notion.so/notion-auth";
 const MAIL_PAGE = "https://mail.notion.so/notion-auth";
@@ -37,6 +37,7 @@ class TabsService {
 	#options = null;
 	#store = null;
 	#mainBus = null;
+	#layoutQueued = false;
 
 	constructor(window, optionsService, store, mainBus) {
 		this.#window = window;
@@ -198,7 +199,21 @@ class TabsService {
 			Object.values(this.#tabViews).forEach((view) => view.webContents.close());
 		});
 
-		this.#window.on("resize", this.#setViewSize.bind(this));
+		this.#window.contentView.on(
+			"bounds-changed",
+			this.#queueSetViewSize.bind(this),
+		);
+
+		[
+			"resize",
+			"maximize",
+			"unmaximize",
+			"restore",
+			"enter-full-screen",
+			"leave-full-screen",
+		].forEach((eventName) => {
+			this.#window.on(eventName, this.#queueSetViewSize.bind(this));
+		});
 
 		app.on("before-quit", () => {
 			this.#saveTabs();
@@ -221,20 +236,22 @@ class TabsService {
 	}
 
 	#setViewSize() {
-		const bounds = this.#window.getContentBounds();
-		this.#titleBarView.setBounds({
-			x: 0,
-			y: 0,
-			width: bounds.width,
-			height: TITLEBAR_HEIGHT,
-		});
+		const { titlebar, page } = getTabViewLayout(
+			this.#window.contentView.getBounds(),
+		);
+		this.#titleBarView.setBounds(titlebar);
 		Object.values(this.#tabViews).forEach((view) => {
-			view.setBounds({
-				x: 0,
-				y: TITLEBAR_HEIGHT,
-				width: bounds.width,
-				height: bounds.height - TITLEBAR_HEIGHT,
-			});
+			view.setBounds(page);
+		});
+	}
+
+	#queueSetViewSize() {
+		if (this.#layoutQueued) return;
+
+		this.#layoutQueued = true;
+		setImmediate(() => {
+			this.#layoutQueued = false;
+			this.#setViewSize();
 		});
 	}
 
@@ -265,13 +282,8 @@ class TabsService {
 			view.webContents.openDevTools({ mode: "detach" });
 		}
 
-		const bounds = this.#window.getContentBounds();
-		view.setBounds({
-			x: 0,
-			y: TITLEBAR_HEIGHT,
-			width: bounds.width,
-			height: bounds.height - TITLEBAR_HEIGHT,
-		});
+		const { page } = getTabViewLayout(this.#window.contentView.getBounds());
+		view.setBounds(page);
 
 		view.webContents
 			.loadURL(url ?? HOME_PAGE, {

--- a/services/viewLayout.mjs
+++ b/services/viewLayout.mjs
@@ -1,0 +1,22 @@
+export const TITLEBAR_HEIGHT = 40;
+
+export function getTabViewLayout({ width, height }, titlebarHeight = TITLEBAR_HEIGHT) {
+	const layoutWidth = Math.max(0, Math.round(width ?? 0));
+	const layoutHeight = Math.max(0, Math.round(height ?? 0));
+	const toolbarHeight = Math.min(titlebarHeight, layoutHeight);
+
+	return {
+		titlebar: {
+			x: 0,
+			y: 0,
+			width: layoutWidth,
+			height: toolbarHeight,
+		},
+		page: {
+			x: 0,
+			y: toolbarHeight,
+			width: layoutWidth,
+			height: Math.max(0, layoutHeight - toolbarHeight),
+		},
+	};
+}

--- a/test/viewLayout.test.mjs
+++ b/test/viewLayout.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getTabViewLayout } from "../services/viewLayout.mjs";
+
+test("sizes the titlebar and page view to the current content view", () => {
+	assert.deepEqual(getTabViewLayout({ width: 1920, height: 1040 }), {
+		titlebar: { x: 0, y: 0, width: 1920, height: 40 },
+		page: { x: 0, y: 40, width: 1920, height: 1000 },
+	});
+});
+
+test("keeps page height non-negative for very small windows", () => {
+	assert.deepEqual(getTabViewLayout({ width: 320, height: 24 }), {
+		titlebar: { x: 0, y: 0, width: 320, height: 24 },
+		page: { x: 0, y: 24, width: 320, height: 0 },
+	});
+});


### PR DESCRIPTION
**ATTENTION**
This change was done using Codex, as I personally don't have enough profficiency in JS/Electron, however it does seem to work without any issues, albeit the content is a bit slow to resize after maximalization.

## Summary

Fixes an issue where the Notion content view could remain at its previous size after maximizing, restoring, or snapping the app window, leaving blank space below the page.

## What Changed

- Added a small layout helper for calculating titlebar and page view bounds.
- Updated tab view sizing to use `window.contentView.getBounds()` instead of `window.getContentBounds()`, so child `WebContentsView` bounds are calculated in the correct coordinate space.
- Relayout now runs on `contentView` bounds changes and window state changes like maximize, restore, fullscreen enter/leave, and resize.
- Added unit tests for the layout calculation.
- Updated `npm test` to run Node’s built-in test runner.

## Testing

- Ran `npm test`
- Ran `node --check services/tabs.mjs`
- Ran `node --check services/viewLayout.mjs`

Manual check: maximize, restore, snap, and resize the app window. The Notion page should continue filling the full area below the custom titlebar.