### PR TITLE
Feature/addendum to disable auto update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Run program with this flags to enable features:
 
 - `--hide-on-startup` – This flag allows the application to start without opening the main window. It is useful when you add the client to your autostart programs list, since it will launch minimized to the tray.
 - `--disable-spellcheck` – Disables OS-defined spellcheck.
-- `--disable-auto-update` – Disables automatic update checks on startup, regardless of the in-app setting.
+- `--disable-update-functionality` – Disables all update functionality (automatic checks, downloads, and installs). Recommended for sandboxed package formats like nix, where updates are managed by the package manager, regardless of the in-app setting.
 
 ### Spellcheck dictionaries
 

--- a/assets/pages/options.html
+++ b/assets/pages/options.html
@@ -1,917 +1,980 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Notion Electron Options</title>
-	<style>
-:root {
-	--bg: #191919;
-	--bg-sidebar: #202020;
-	--bg-selected: #262626;
-	--border-sidebar: rgba(255, 255, 255, 0.05);
-	--border-sidebar-hover: rgba(255, 255, 255, 0.1);
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Notion Electron Options</title>
+		<style>
+			:root {
+				--bg: #191919;
+				--bg-sidebar: #202020;
+				--bg-selected: #262626;
+				--border-sidebar: rgba(255, 255, 255, 0.05);
+				--border-sidebar-hover: rgba(255, 255, 255, 0.1);
 
-	--color: #9b9b9b;
-	--color-hover: #fff;
+				--color: #9b9b9b;
+				--color-hover: #fff;
 
-	--checked: #0D47A1;
+				--checked: #0d47a1;
 
-	--font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI Variable Display", "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-	--font: 500 14px/22px var(--font-family);
+				--font-family:
+					ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI Variable Display', 'Segoe UI',
+					Helvetica, 'Apple Color Emoji', Arial, sans-serif, 'Segoe UI Emoji', 'Segoe UI Symbol';
+				--font: 500 14px/22px var(--font-family);
 
-	--status-important: #f57f1703;
-	--status-important-border: #f9a8252b;
-	--status-error: #B71C1C03;
-	--status-error-border: #C628282b;
-	--statuc-success: #1B5E200a;
-	--status-success-border: #2E7D3252;
+				--status-important: #f57f1703;
+				--status-important-border: #f9a8252b;
+				--status-error: #b71c1c03;
+				--status-error-border: #c628282b;
+				--statuc-success: #1b5e200a;
+				--status-success-border: #2e7d3252;
 
-	--spinner-indicator: #FFF2;
-	--spinner-indicator-highlight: #FFF;
-}
-@media (prefers-color-scheme: light) {
-	:root {
-		--bg: #fff;
-		--bg-sidebar: #f8f8f7;
-		--bg-selected: rgba(0, 0, 0, 0.055);
-		--border-sidebar: #ccc;
-		--border-sidebar-hover: rgba(0, 0, 0, 0.1);
-
-		--color: #37352f;
-		--color-hover: #1d1b16;
-
-		--checked: #1976D2;
-
-		--status-important: #f57f1710;
-		--status-important-border: #f9a82563;
-		--status-error: #B71C1C0c;
-		--status-error-border: #C628283d;
-		--statuc-success: #1B5E200a;
-		--status-success-border: #2E7D3252;
-
-		--spinner-indicator: #1d1b1622;
-		--spinner-indicator-highlight: #1d1b16;
-	}
-}
-html,body {
-	background-color: var(--bg);
-	color: var(--color);
-	font: var(--font);
-	margin: 0;
-	padding: 0;
-	min-width: 100%;
-	min-height: 100%;
-	width: 100%;
-	height: 100%;
-}
-a{
-	color: var(--color);
-}
-a:hover {
-	color: var(--color-hover);
-}
-input[type="checkbox"] {
-	appearance: none;
-	width: 16px;
-	height: 16px;
-	border: 1px solid var(--color);
-	border-radius: 2px;
-	background-color: transparent;
-	outline: none;
-	cursor: pointer;
-	margin: 0;
-}
-input[type="checkbox"]:checked {
-	background-color: var(--checked);
-	border-color: var(--checked);
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='%23fff'%3E%3Cpath d='m400-456 217-216q20-20 47-20t47 20q21 20 21 47.5T711-577L448-313q-20 21-48 21t-48-21L248-417q-20-20-20-47.5t21-47.5q20-20 47.5-20t47.5 20l56 56Z'/%3E%3C/svg%3E");
-	background-size: 16px;
-	background-repeat: no-repeat;
-	background-position: center;
-}
-input[type="checkbox"]:focus {
-	box-shadow: 0 0 0 2px var(--color);
-}
-select {
-	appearance: none;
-	border: 1px solid var(--color);
-	border-radius: 2px;
-	background-color: transparent;
-	color: var(--color);
-	padding: 5px 30px 5px 10px;
-	outline: none;
-	cursor: pointer;
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='%239b9b9b'%3E%3Cpath d='M480-394q-6 0-10.75-2t-9.25-7L288.5-574.5q-4-3.5-4.25-8.5t4.25-9.5q4.5-4.5 9-4.5t9 4.5L480-419l173.5-173.5q3.5-3.5 8.5-4t9.5 4q4.5 4.5 4.75 9t-4.25 9L500.5-403q-5 5-9.75 7T480-394Z'/%3E%3C/svg%3E");
-	background-size: 24px;
-	background-repeat: no-repeat;
-	background-position: right 1px center;
-	width: 100%;
-}
-select:focus {
-	box-shadow: 0 0 0 2px var(--color);
-}
-option {
-	background-color: var(--bg-sidebar);
-	color: var(--color);
-}
-option:hover,
-option:focus {
-	color: var(--color-hover);
-}
-option:checked {
-	font-weight: 700;
-}
-button {
-	appearance: none;
-	border: none;
-	border-radius: 2px;
-	background-color: var(--border-sidebar);
-	color: var(--color);
-	padding: 10px 20px;
-	cursor: pointer;
-	outline: none;
-}
-button:hover {
-	color: var(--color-hover);
-}
-button.primary {
-	background-color: var(--checked);
-	color: #fff;
-}
-button.primary:hover {
-	background-color: var(--checked);
-}
-button:active {
-	background-color: var(--border-sidebar);
-}
-button:focus {
-	box-shadow: 0 0 0 2px var(--color);
-}
-
-
-.container {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	width: 100%;
-}
-.tabgroup {
-	flex: 0 0 auto;
-	display: flex;
-	flex-direction: row;
-	user-select: none;
-}
-.tab {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	padding: 10px 20px;
-	cursor: pointer;
-	min-width: 100px;
-	box-sizing: border-box;
-	justify-content: center;
-	gap: 10px;
-	color: var(--color);
-	outline: none;
-	text-decoration: none;
-}
-.tab:focus {
-	color: var(--color-hover);
-}
-.tab:hover {
-	background-color: var(--bg-sidebar);
-}
-.tab.selected {
-	background-color: var(--bg-selected);
-}
-.indicator {
-	color: #c00;
-}
-
-.content {
-	flex: 1 1 auto;
-	background-color: var(--bg-selected);
-	border-bottom: 1px solid var(--border-sidebar);
-	box-sizing: border-box;
-	min-height: 0;
-	overflow: hidden;
-	overflow-y: scroll;
-	scrollbar-color: var(--bg) var(--bg-selected);
-}
-
-.footer {
-	box-sizing: border-box;
-	display: flex;
-	flex-direction: row;
-	justify-content: end;
-	padding: 20px;
-	gap: 20px;
-}
-
-.tab-panel {}
-
-.about {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	box-sizing: border-box;
-	padding: 20px;
-	width: 100%;
-	min-height: 100%;
-}
-.logo {
-	width: 96px;
-	height: 96px;
-	margin-bottom: 20px;
-}
-.about-name {
-	margin: 0;
-}
-.about-text {
-	margin: 0;
-	width: 400px;
-}
-.about-version {
-	width: auto;
-	margin-bottom: 20px;
-}
-
-.options {
-	display: flex;
-	flex-direction: column;
-	align-items: start;
-	justify-content: start;
-	box-sizing: border-box;
-	width: 100%;
-	min-height: 100%;
-}
-.grid {
-	display: flex;
-	flex-direction: column;
-	align-items: start;
-	justify-content: start;
-	width: 100%;
-}
-.grid-row {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: start;
-	gap: 20px;
-	width: 100%;
-	box-sizing: border-box;
-	padding: 10px 20px;
-}
-.grid-row:hover {
-	background-color: var(--border-sidebar);
-	color: var(--color-hover);
-}
-.option-group {
-	margin: 30px 0 10px;
-	padding: 0 20px;
-	line-height: 24px;
-	font-size: 24px;
-}
-.option {
-	flex: 2 2 auto;
-	font-weight: 500;
-	min-width: 0;
-	width: 66%;
-}
-.option-control {
-	flex: 1 1 auto;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: start;
-	min-width: 0;
-	width: 33%;
-}
-
-.updates {
-	display: flex;
-	flex-direction: column;
-	align-items: start;
-	justify-content: start;
-	box-sizing: border-box;
-	width: 100%;
-	min-height: 100%;
-	padding: 20px;
-	gap: 20px;
-}
-
-.update-status {
-	display: flex;
-	flex-direction: column;
-	align-items: start;
-	justify-content: start;
-	gap: 10px;
-	width: 100%;
-}
-.status-row {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: start;
-	gap: 10px;
-	width: 100%;
-}
-.status-label {
-	opacity: 0.8;
-	flex: 0 0 130px;
-}
-.status-value {
-	font-family: monospace;
-	flex: 1 1 auto;
-}
-
-.update-stage {
-	display: flex;
-	flex-direction: column;
-	box-sizing: border-box;
-	width: 100%;
-	padding: 20px 20px 20px 50px;
-	border-radius: 4px;
-	position: relative;
-	border: 1px solid var(--border-sidebar);
-	background-color: var(--bg-sidebar);
-}
-.update-stage::before {
-	content: '';
-	position: absolute;
-	top: 18px;
-	left: 18px;
-	width: 24px;
-	height: 24px;
-	background-image: url('../icons/dark/status_done.svg');
-	opacity: 0.8;
-}
-.align-end {
-	align-self: end;
-}
-
-.stage-label {
-	margin: 0;
-	font-weight: 700;
-}
-
-.stage-progress {
-	width: 100%;
-	margin: 20px 0 10px;
-}
-.stage-progress-info {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: space-between;
-	width: 100%;
-	font: 400 9pt/12pt monospace;
-	opacity: 0.8;
-}
-
-.stage-installing::before,
-.stage-checking::before {
-	background-image: url('../icons/dark/status_waiting.svg');
-}
-.stage-available::before {
-	background-image: url('../icons/dark/status_important.svg');
-}
-.stage-downloading::before {
-	background-image: url('../icons/dark/status_loading.svg');
-}
-.stage-error::before {
-	background-image: url('../icons/dark/status_error.svg');
-}
-
-.stage-available {
-	border-color: var(--status-important-border);
-	background-color: var(--status-important);
-}
-.stage-installed {
-	border-color: var(--status-success-border);
-	background-color: var(--statuc-success);
-}
-.stage-error {
-	border-color: var(--status-error-border);
-	background-color: var(--status-error);
-}
-
-.stage-progress {
-	appearance: none;
-	box-sizing: border-box;
-	border: solid 1px var(--border-sidebar);
-	width: 100%;
-	height: 20px;
-	border-radius: 20px;
-	background-clip: content-box;
-	background-image: linear-gradient(to bottom, var(--bg), var(--bg-sidebar));
-	overflow: hidden;
-
-	--animated-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20" preserveAspectRatio="xMidYMid"><defs><linearGradient id="b" gradientTransform="rotate(90)"><stop offset="0" stop-color="%232979FF" /><stop offset="1" stop-color="%232962FF" /></linearGradient><pattern id="z" patternUnits="userSpaceOnUse" width="100" height="100"><g transform="translate(0)"><rect fill="url(%23b)" width="20" height="20" x="-20" /><rect fill="url(%23b)" width="20" height="20" x="20" /><animateTransform attributeName="transform" type="translate" values="0 0;40 0" keyTimes="0;1" repeatCount="indefinite" dur="1s"/></g></pattern></defs><rect width="40" height="20" fill="url(%23z)" /></svg>');
-}
-.stage-progress::-webkit-progress-bar { background: transparent }
-.stage-progress::-webkit-progress-value {
-	background-color: var(--checked);
-	background-image:
-		radial-gradient(ellipse , #ffffff38, transparent 80%),
-		var(--animated-bg),
-		linear-gradient(to top, #2962FFd0, #2979FFd0);
-	;
-	background-size: auto 5px, contain, auto;
-	background-repeat: no-repeat, repeat-x, no-repeat;
-	background-position: 0 2px, 0 0, 0 0;
-	border-radius: 20px;
-	transition: width 0.2s ease-in-out;
-	box-shadow: 0 2px 5px var(--bg-sidebar);
-}
-
-.changelog {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	box-sizing: border-box;
-	width: 100%;
-	min-height: 200px;
-	padding: 0 20px;
-}
-.changelog dl {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	gap: 20px;
-	margin: 0;
-}
-.changelog dt {
-	display: block;
-	margin: 0;
-	padding: 0;
-	flex: 0 0 180px;
-}
-.changelog dd {
-	display: block;
-	margin: 0 0 20px;
-	padding: 0;
-	flex: 1 1 calc(100% - 200px);
-}
-.changelog small,
-.subheader {
-	opacity: 0.8;
-}
-
-.spinner {
-	width: 10px;
-	height: 10px;
-	border-radius: 50%;
-	background-color: var(--spinner-indicator-highlight);
-	box-shadow: 20px 0 var(--spinner-indicator-highlight), -20px 0 var(--spinner-indicator-highlight);
-	position: relative;
-	animation: flash 0.5s ease-out infinite alternate;
-}
-
-@keyframes flash {
-	0% {
-		background-color: var(--spinner-indicator);
-		box-shadow: 20px 0 var(--spinner-indicator), -20px 0 var(--spinner-indicator-highlight);
-	}
-	50% {
-		background-color: var(--spinner-indicator-highlight);
-		box-shadow: 20px 0 var(--spinner-indicator), -20px 0 var(--spinner-indicator);
-	}
-	100% {
-		background-color: var(--spinner-indicator);
-		box-shadow: 20px 0 var(--spinner-indicator-highlight), -20px 0 var(--spinner-indicator);
-	}
-}
-
-
-@media (prefers-color-scheme: light) {
-	select {
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='37352f'%3E%3Cpath d='M480-394q-6 0-10.75-2t-9.25-7L288.5-574.5q-4-3.5-4.25-8.5t4.25-9.5q4.5-4.5 9-4.5t9 4.5L480-419l173.5-173.5q3.5-3.5 8.5-4t9.5 4q4.5 4.5 4.75 9t-4.25 9L500.5-403q-5 5-9.75 7T480-394Z'/%3E%3C/svg%3E");
-	}
-	html, body,
-	.grid-row:hover {
-		background-color: var(--bg-sidebar);
-	}
-	.tab:hover,
-	.tab.selected,
-	.content {
-		background-color: var(--bg);
-		scrollbar-color: var(--border-sidebar) var(--bg);
-	}
-	button {
-		background-color: var(--bg);
-		border: 1px solid var(--border-sidebar-hover);
-	}
-	button:hover {
-		border-color: var(--border-sidebar);
-	}
-	button.primary { border: none }
-
-	.update-stage::before {
-		background-image: url('../icons/light/status_done.svg');
-	}
-	.stage-installing::before,
-	.stage-checking::before {
-		background-image: url('../icons/light/status_waiting.svg');
-	}
-	.stage-available::before {
-		background-image: url('../icons/light/status_important.svg');
-	}
-	.stage-downloading::before {
-		background-image: url('../icons/light/status_loading.svg');
-	}
-	.stage-error::before {
-		background-image: url('../icons/light/status_error.svg');
-	}
-
-	.stage-progress {
-		background-image: linear-gradient(to bottom, var(--bg-selected), var(--bg));
-		--animated-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20" preserveAspectRatio="xMidYMid"><defs><linearGradient id="b" gradientTransform="rotate(90)"><stop offset="0" stop-color="%2300B0FF" /><stop offset="1" stop-color="%230091EA" /></linearGradient><pattern id="z" patternUnits="userSpaceOnUse" width="100" height="100"><g transform="translate(0)"><rect fill="url(%23b)" width="20" height="20" x="-20" /><rect fill="url(%23b)" width="20" height="20" x="20" /><animateTransform attributeName="transform" type="translate" values="0 0;40 0" keyTimes="0;1" repeatCount="indefinite" dur="1s"/></g></pattern></defs><rect width="40" height="20" fill="url(%23z)" /></svg>');
-	}
-	.stage-progress::-webkit-progress-value {
-		background-image:
-			radial-gradient(ellipse , #ffffff38, transparent 80%),
-			var(--animated-bg),
-			linear-gradient(to top, #0091EAd0, #00B0FFd0);
-		;
-		box-shadow: 0 2px 5px var(--bg-selected);
-	}
-}
-
-.hidden {
-	display: none;
-}
-	</style>
-</head>
-<body>
-	<template id="option-checkbox">
-		<div class="grid-row">
-			<div class="option">
-				<label for="option-id">Option Name</label>
-			</div>
-			<div class="option-control">
-				<input type="checkbox" id="option-id" />
-			</div>
-		</div>
-	</template>
-	<template id="option-select">
-		<div class="grid-row">
-			<div class="option">
-				<label for="select-id">Select Name</label>
-			</div>
-			<div class="option-control">
-				<select id="select-id">
-				</select>
-			</div>
-		</div>
-	</template>
-	<template id="option-group">
-		<h1 class="option-group">Group Name</h1>
-		<div class="grid"></div>
-	</template>
-
-	<div class="container">
-		<div class="tabgroup">
-			<a class="tab" id="options" href="#options" target="_self">
-				<span class="indicator hidden">●</span>
-				<span class="tab-title">Options</span>
-			</a>
-			<a class="tab" id="updates" href="#updates" target="_self">
-				<span class="indicator hidden">●</span>
-				<span class="tab-title">Updates</span>
-			</a>
-			<a class="tab" id="about" href="#about" target="_self">
-				<span class="indicator hidden">●</span>
-				<span class="tab-title">About</span>
-			</a>
-		</div>
-		<div class="content">
-			<div class="tab-panel options" data-for="options"></div>
-			<div class="tab-panel updates" data-for="updates">
-				<div class="update-status">
-					<div class="status-row">
-						<div class="status-label">Last checked:</div>
-						<div class="status-value" id="status-date"></div>
-					</div>
-					<div class="status-row">
-						<div class="status-label">Available version:</div>
-						<div class="status-value" id="status-available"></div>
-					</div>
-					<div class="status-row">
-						<div class="status-label">Your version:</div>
-						<div class="status-value" id="status-local"></div>
-					</div>
-				</div>
-
-				<div class="update-stage stage-latest hidden">
-					<p class="stage-label">You are using latest version</p>
-					<button class="align-end" role="button" id="update-manually">Check For Updates Manually</button>
-				</div>
-
-				<div class="update-stage stage-checking hidden">
-					<p class="stage-label">Checking update...</p>
-				</div>
-
-				<div class="update-stage stage-available hidden">
-					<p class="stage-label">New version is available!</p>
-					<button class="align-end" role="button" id="update-download">Download and Install</button>
-				</div>
-
-				<div class="update-stage stage-downloading hidden">
-					<p class="stage-label">Downloading update...</p>
-					<progress class="stage-progress" id="update-progress" value="0" max="100"></progress>
-					<div class="stage-progress-info">
-						<div class="stage-progress-info-cell">
-							<span id="update-percent"></span>
-							(<span id="update-downloaded"></span> / <span id="update-total"></span>)
-						</div>
-						<div class="stage-progress-info-cell">
-							<span id="update-speed"></span>
-						</div>
-					</div>
-				</div>
-
-				<div class="update-stage stage-ready hidden">
-					<p class="stage-label">New version is ready to install</p>
-					<button class="align-end" role="button" id="update-install">Restart And Install</button>
-				</div>
-
-				<div class="update-stage stage-installing hidden">
-					<p class="stage-label">Installing update...</p>
-				</div>
-
-				<div class="update-stage stage-installed hidden">
-					<p class="stage-label">New version is installed. It will be applied on next restart.</p>
-				</div>
-
-				<div class="update-stage stage-error hidden">
-					<p class="stage-label">An error occurred while updating</p>
-					<pre class="error-message" id="update-error"></pre>
-					<div>Restart app and try to update later.</div>
-				</div>
-
-				<span class="subheader">Changelog:</span>
-				<div class="changelog" id="changelog">
-					<span class="spinner"></span>
-				</div>
-			</div>
-			<div class="tab-panel about" data-for="about">
-				<img src="../logo.svg" alt="Notion Electron" class="logo" />
-				<h1 class="about-name">Notion Electron</h1>
-				<p class="about-text about-version">Version: <span id="version">0.0.0</span></p>
-				<p class="about-text" id="description">Unofficial Notion client</p>
-				<p class="about-text">Developed by <span id="author">Artem Nechunaev</span></p>
-				<p class="about-text">License: <span id="license">MIT</span></p>
-				<p class="about-text">Source code: <a href="https://github.com/anechunaev/notion-electron" target="_blank" id="source">github.com/anechunaev/notion-electron</a></p>
-			</div>
-		</div>
-		<div class="footer">
-			<button class="button" role="button" id="cancel">Cancel</button>
-			<button class="button primary" role="button" id="restart">Save and Restart</button>
-		</div>
-	</div>
-
-	<script>
-document.addEventListener('DOMContentLoaded', () => {
-	let currentTab = null;
-	let changelog = null;
-
-	const cancel = document.getElementById('cancel');
-	const restart = document.getElementById('restart');
-	const tabs = Array.from(document.querySelectorAll('.tab'));
-	const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
-	const templates = {
-		checkbox: document.getElementById('option-checkbox'),
-		select: document.getElementById('option-select'),
-		group: document.getElementById('option-group'),
-	};
-	const stageLatest = document.querySelector('.stage-latest');
-	const stageChecking = document.querySelector('.stage-checking');
-	const stageAvailable = document.querySelector('.stage-available');
-	const stageDownloading = document.querySelector('.stage-downloading');
-	const stageReady = document.querySelector('.stage-ready');
-	const stageInstalling = document.querySelector('.stage-installing');
-	const stageInstalled = document.querySelector('.stage-installed');
-	const stageError = document.querySelector('.stage-error');
-	const statusDate = document.getElementById('status-date');
-	const statusAvailable = document.getElementById('status-available');
-	const statusLocal = document.getElementById('status-local');
-	const updateManually = document.getElementById('update-manually');
-	const updateDownload = document.getElementById('update-download');
-	const updateProgress = document.getElementById('update-progress');
-	const updatePercentage = document.getElementById('update-percent');
-	const updateDownloaded = document.getElementById('update-downloaded');
-	const updateTotal = document.getElementById('update-total');
-	const updateSpeed = document.getElementById('update-speed');
-	const updateInstall = document.getElementById('update-install');
-	const updateError = document.getElementById('update-error');
-	const updateStages = [
-		stageLatest,
-		stageChecking,
-		stageAvailable,
-		stageDownloading,
-		stageReady,
-		stageInstalling,
-		stageInstalled,
-		stageError,
-	];
-	const changelogElement = document.getElementById('changelog');
-
-	function selectTab(tabId) {
-		if (tabId === currentTab) return;
-		currentTab = tabId;
-
-		tabs.forEach(t => {
-			t.classList.toggle('selected', t.id === currentTab);
-		});
-		tabPanels.forEach(panel => {
-			panel.classList.toggle('hidden', panel.dataset.for !== currentTab);
-		});
-
-		if (tabId === 'updates' && !changelog) {
-			window.notionElectronAPI.requestChangelog();
-		}
-	}
-
-	function toggleIndicator(tabId, value) {
-		const tab = tabs.find(t => t.id === tabId);
-		if (!tab) return;
-		const indicator = tab.querySelector('.indicator');
-		if (!indicator) return;
-		if (typeof value === 'undefined') {
-			value = !indicator.classList.contains('hidden');
-		}
-		indicator.classList.toggle('hidden', !value);
-	}
-
-	tabs.forEach(tab => {
-		tab.addEventListener('click', () => {
-			selectTab(tab.id);
-		});
-	});
-
-	const hash = window.location.hash.slice(1);
-	if (hash) {
-		selectTab(hash);
-	} else {
-		window.location.hash = tabs[0].id;
-		selectTab(tabs[0].id);
-	}
-
-	window.notionElectronAPI.getAppMetadata();
-	window.notionElectronAPI.getOptions();
-	window.notionElectronAPI.requestUpdateStatus();
-
-	window.notionElectronAPI.subscribeOnOptions((config) => {
-		const optionsPanel = document.querySelector('.tab-panel.options');
-		optionsPanel.innerHTML = '';
-		const options = Object.entries(config.options).map(([id, option]) => {
-			return {
-				id,
-				...option,
-			};
-		});
-		const groups = Object.entries(config.groups).reduce((acc, [id, groupName]) => {
-			acc[id] = {
-				id,
-				name: groupName,
-				el: document.importNode(templates.group.content, true),
-				options: [],
-			};
-			acc[id].el.querySelector('h1').textContent = groupName;
-			acc[id].grid = acc[id].el.querySelector('.grid');
-			return acc;
-		}, {});
-		groups.nogroup = {
-			id: 'nogroup',
-			el: document.importNode(templates.group.content, true),
-			options: [],
-		};
-		groups.nogroup.el.querySelector('h1').textContent = 'Other Options';
-		groups.nogroup.grid = groups.nogroup.el.querySelector('.grid');
-
-		options.forEach(option => {
-			const template = templates[option.value.type];
-			if (!template) return;
-			const clone = document.importNode(template.content, true);
-			const label = clone.querySelector('label');
-			const input = clone.querySelector('input, select');
-			label.textContent = option.name;
-			label.htmlFor = option.id;
-			input.id = option.id;
-			input.name = option.id;
-			if (option.value.type === 'select') {
-				const select = input;
-				Object.entries(option.value.options).forEach(([optionValue, optionName]) => {
-					const option = document.createElement('option');
-					option.value = optionValue;
-					option.textContent = optionName;
-					select.appendChild(option);
-				});
-				select.value = option.value.data ?? option.value.default;
+				--spinner-indicator: #fff2;
+				--spinner-indicator-highlight: #fff;
 			}
-			if (option.value.type === 'checkbox') {
-				input.checked = option.value.data ? 'on' : '';
-			}
-			input.addEventListener('change', (e) => {
-				if (option.value.type === 'checkbox') {
-					window.notionElectronAPI.setOption(option.id, e.currentTarget.checked);
-				} else {
-					window.notionElectronAPI.setOption(option.id, e.target.value);
+			@media (prefers-color-scheme: light) {
+				:root {
+					--bg: #fff;
+					--bg-sidebar: #f8f8f7;
+					--bg-selected: rgba(0, 0, 0, 0.055);
+					--border-sidebar: #ccc;
+					--border-sidebar-hover: rgba(0, 0, 0, 0.1);
+
+					--color: #37352f;
+					--color-hover: #1d1b16;
+
+					--checked: #1976d2;
+
+					--status-important: #f57f1710;
+					--status-important-border: #f9a82563;
+					--status-error: #b71c1c0c;
+					--status-error-border: #c628283d;
+					--statuc-success: #1b5e200a;
+					--status-success-border: #2e7d3252;
+
+					--spinner-indicator: #1d1b1622;
+					--spinner-indicator-highlight: #1d1b16;
 				}
+			}
+			html,
+			body {
+				background-color: var(--bg);
+				color: var(--color);
+				font: var(--font);
+				margin: 0;
+				padding: 0;
+				min-width: 100%;
+				min-height: 100%;
+				width: 100%;
+				height: 100%;
+			}
+			a {
+				color: var(--color);
+			}
+			a:hover {
+				color: var(--color-hover);
+			}
+			input[type='checkbox'] {
+				appearance: none;
+				width: 16px;
+				height: 16px;
+				border: 1px solid var(--color);
+				border-radius: 2px;
+				background-color: transparent;
+				outline: none;
+				cursor: pointer;
+				margin: 0;
+			}
+			input[type='checkbox']:checked {
+				background-color: var(--checked);
+				border-color: var(--checked);
+				background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='%23fff'%3E%3Cpath d='m400-456 217-216q20-20 47-20t47 20q21 20 21 47.5T711-577L448-313q-20 21-48 21t-48-21L248-417q-20-20-20-47.5t21-47.5q20-20 47.5-20t47.5 20l56 56Z'/%3E%3C/svg%3E");
+				background-size: 16px;
+				background-repeat: no-repeat;
+				background-position: center;
+			}
+			input[type='checkbox']:focus {
+				box-shadow: 0 0 0 2px var(--color);
+			}
+			select {
+				appearance: none;
+				border: 1px solid var(--color);
+				border-radius: 2px;
+				background-color: transparent;
+				color: var(--color);
+				padding: 5px 30px 5px 10px;
+				outline: none;
+				cursor: pointer;
+				background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='%239b9b9b'%3E%3Cpath d='M480-394q-6 0-10.75-2t-9.25-7L288.5-574.5q-4-3.5-4.25-8.5t4.25-9.5q4.5-4.5 9-4.5t9 4.5L480-419l173.5-173.5q3.5-3.5 8.5-4t9.5 4q4.5 4.5 4.75 9t-4.25 9L500.5-403q-5 5-9.75 7T480-394Z'/%3E%3C/svg%3E");
+				background-size: 24px;
+				background-repeat: no-repeat;
+				background-position: right 1px center;
+				width: 100%;
+			}
+			select:focus {
+				box-shadow: 0 0 0 2px var(--color);
+			}
+			option {
+				background-color: var(--bg-sidebar);
+				color: var(--color);
+			}
+			option:hover,
+			option:focus {
+				color: var(--color-hover);
+			}
+			option:checked {
+				font-weight: 700;
+			}
+			button {
+				appearance: none;
+				border: none;
+				border-radius: 2px;
+				background-color: var(--border-sidebar);
+				color: var(--color);
+				padding: 10px 20px;
+				cursor: pointer;
+				outline: none;
+			}
+			button:hover {
+				color: var(--color-hover);
+			}
+			button.primary {
+				background-color: var(--checked);
+				color: #fff;
+			}
+			button.primary:hover {
+				background-color: var(--checked);
+			}
+			button:active {
+				background-color: var(--border-sidebar);
+			}
+			button:focus {
+				box-shadow: 0 0 0 2px var(--color);
+			}
+			button:disabled {
+				opacity: 0.4;
+				cursor: not-allowed;
+			}
+
+			.container {
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+				width: 100%;
+			}
+			.tabgroup {
+				flex: 0 0 auto;
+				display: flex;
+				flex-direction: row;
+				user-select: none;
+			}
+			.tab {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				padding: 10px 20px;
+				cursor: pointer;
+				min-width: 100px;
+				box-sizing: border-box;
+				justify-content: center;
+				gap: 10px;
+				color: var(--color);
+				outline: none;
+				text-decoration: none;
+			}
+			.tab:focus {
+				color: var(--color-hover);
+			}
+			.tab:hover {
+				background-color: var(--bg-sidebar);
+			}
+			.tab.selected {
+				background-color: var(--bg-selected);
+			}
+			.indicator {
+				color: #c00;
+			}
+
+			.content {
+				flex: 1 1 auto;
+				background-color: var(--bg-selected);
+				border-bottom: 1px solid var(--border-sidebar);
+				box-sizing: border-box;
+				min-height: 0;
+				overflow: hidden;
+				overflow-y: scroll;
+				scrollbar-color: var(--bg) var(--bg-selected);
+			}
+
+			.footer {
+				box-sizing: border-box;
+				display: flex;
+				flex-direction: row;
+				justify-content: end;
+				padding: 20px;
+				gap: 20px;
+			}
+
+			.tab-panel {
+			}
+
+			.about {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				box-sizing: border-box;
+				padding: 20px;
+				width: 100%;
+				min-height: 100%;
+			}
+			.logo {
+				width: 96px;
+				height: 96px;
+				margin-bottom: 20px;
+			}
+			.about-name {
+				margin: 0;
+			}
+			.about-text {
+				margin: 0;
+				width: 400px;
+			}
+			.about-version {
+				width: auto;
+				margin-bottom: 20px;
+			}
+
+			.options {
+				display: flex;
+				flex-direction: column;
+				align-items: start;
+				justify-content: start;
+				box-sizing: border-box;
+				width: 100%;
+				min-height: 100%;
+			}
+			.grid {
+				display: flex;
+				flex-direction: column;
+				align-items: start;
+				justify-content: start;
+				width: 100%;
+			}
+			.grid-row {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				justify-content: start;
+				gap: 20px;
+				width: 100%;
+				box-sizing: border-box;
+				padding: 10px 20px;
+			}
+			.grid-row:hover {
+				background-color: var(--border-sidebar);
+				color: var(--color-hover);
+			}
+			.grid-row.disabled,
+			.grid-row.disabled:hover {
+				opacity: 0.4;
+				pointer-events: none;
+				color: var(--color);
+				background-color: transparent;
+			}
+			.option-group {
+				margin: 30px 0 10px;
+				padding: 0 20px;
+				line-height: 24px;
+				font-size: 24px;
+			}
+			.option {
+				flex: 2 2 auto;
+				font-weight: 500;
+				min-width: 0;
+				width: 66%;
+			}
+			.option-control {
+				flex: 1 1 auto;
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				justify-content: start;
+				min-width: 0;
+				width: 33%;
+			}
+
+			.updates {
+				display: flex;
+				flex-direction: column;
+				align-items: start;
+				justify-content: start;
+				box-sizing: border-box;
+				width: 100%;
+				min-height: 100%;
+				padding: 20px;
+				gap: 20px;
+			}
+
+			.update-status {
+				display: flex;
+				flex-direction: column;
+				align-items: start;
+				justify-content: start;
+				gap: 10px;
+				width: 100%;
+			}
+			.status-row {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				justify-content: start;
+				gap: 10px;
+				width: 100%;
+			}
+			.status-label {
+				opacity: 0.8;
+				flex: 0 0 130px;
+			}
+			.status-value {
+				font-family: monospace;
+				flex: 1 1 auto;
+			}
+
+			.update-stage {
+				display: flex;
+				flex-direction: column;
+				box-sizing: border-box;
+				width: 100%;
+				padding: 20px 20px 20px 50px;
+				border-radius: 4px;
+				position: relative;
+				border: 1px solid var(--border-sidebar);
+				background-color: var(--bg-sidebar);
+			}
+			.update-stage::before {
+				content: '';
+				position: absolute;
+				top: 18px;
+				left: 18px;
+				width: 24px;
+				height: 24px;
+				background-image: url('../icons/dark/status_done.svg');
+				opacity: 0.8;
+			}
+			.align-end {
+				align-self: end;
+			}
+
+			.stage-label {
+				margin: 0;
+				font-weight: 700;
+			}
+
+			.stage-progress {
+				width: 100%;
+				margin: 20px 0 10px;
+			}
+			.stage-progress-info {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				justify-content: space-between;
+				width: 100%;
+				font: 400 9pt/12pt monospace;
+				opacity: 0.8;
+			}
+
+			.stage-installing::before,
+			.stage-checking::before {
+				background-image: url('../icons/dark/status_waiting.svg');
+			}
+			.stage-available::before {
+				background-image: url('../icons/dark/status_important.svg');
+			}
+			.stage-downloading::before {
+				background-image: url('../icons/dark/status_loading.svg');
+			}
+			.stage-error::before {
+				background-image: url('../icons/dark/status_error.svg');
+			}
+
+			.stage-available {
+				border-color: var(--status-important-border);
+				background-color: var(--status-important);
+			}
+			.stage-installed {
+				border-color: var(--status-success-border);
+				background-color: var(--statuc-success);
+			}
+			.stage-error {
+				border-color: var(--status-error-border);
+				background-color: var(--status-error);
+			}
+
+			.stage-progress {
+				appearance: none;
+				box-sizing: border-box;
+				border: solid 1px var(--border-sidebar);
+				width: 100%;
+				height: 20px;
+				border-radius: 20px;
+				background-clip: content-box;
+				background-image: linear-gradient(to bottom, var(--bg), var(--bg-sidebar));
+				overflow: hidden;
+
+				--animated-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20" preserveAspectRatio="xMidYMid"><defs><linearGradient id="b" gradientTransform="rotate(90)"><stop offset="0" stop-color="%232979FF" /><stop offset="1" stop-color="%232962FF" /></linearGradient><pattern id="z" patternUnits="userSpaceOnUse" width="100" height="100"><g transform="translate(0)"><rect fill="url(%23b)" width="20" height="20" x="-20" /><rect fill="url(%23b)" width="20" height="20" x="20" /><animateTransform attributeName="transform" type="translate" values="0 0;40 0" keyTimes="0;1" repeatCount="indefinite" dur="1s"/></g></pattern></defs><rect width="40" height="20" fill="url(%23z)" /></svg>');
+			}
+			.stage-progress::-webkit-progress-bar {
+				background: transparent;
+			}
+			.stage-progress::-webkit-progress-value {
+				background-color: var(--checked);
+				background-image:
+					radial-gradient(ellipse, #ffffff38, transparent 80%), var(--animated-bg),
+					linear-gradient(to top, #2962ffd0, #2979ffd0);
+				background-size:
+					auto 5px,
+					contain,
+					auto;
+				background-repeat: no-repeat, repeat-x, no-repeat;
+				background-position:
+					0 2px,
+					0 0,
+					0 0;
+				border-radius: 20px;
+				transition: width 0.2s ease-in-out;
+				box-shadow: 0 2px 5px var(--bg-sidebar);
+			}
+
+			.changelog {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				box-sizing: border-box;
+				width: 100%;
+				min-height: 200px;
+				padding: 0 20px;
+			}
+			.changelog dl {
+				display: flex;
+				flex-direction: row;
+				flex-wrap: wrap;
+				gap: 20px;
+				margin: 0;
+			}
+			.changelog dt {
+				display: block;
+				margin: 0;
+				padding: 0;
+				flex: 0 0 180px;
+			}
+			.changelog dd {
+				display: block;
+				margin: 0 0 20px;
+				padding: 0;
+				flex: 1 1 calc(100% - 200px);
+			}
+			.changelog small,
+			.subheader {
+				opacity: 0.8;
+			}
+
+			.spinner {
+				width: 10px;
+				height: 10px;
+				border-radius: 50%;
+				background-color: var(--spinner-indicator-highlight);
+				box-shadow:
+					20px 0 var(--spinner-indicator-highlight),
+					-20px 0 var(--spinner-indicator-highlight);
+				position: relative;
+				animation: flash 0.5s ease-out infinite alternate;
+			}
+
+			@keyframes flash {
+				0% {
+					background-color: var(--spinner-indicator);
+					box-shadow:
+						20px 0 var(--spinner-indicator),
+						-20px 0 var(--spinner-indicator-highlight);
+				}
+				50% {
+					background-color: var(--spinner-indicator-highlight);
+					box-shadow:
+						20px 0 var(--spinner-indicator),
+						-20px 0 var(--spinner-indicator);
+				}
+				100% {
+					background-color: var(--spinner-indicator);
+					box-shadow:
+						20px 0 var(--spinner-indicator-highlight),
+						-20px 0 var(--spinner-indicator);
+				}
+			}
+
+			@media (prefers-color-scheme: light) {
+				select {
+					background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24px' viewBox='0 -960 960 960' width='24px' fill='37352f'%3E%3Cpath d='M480-394q-6 0-10.75-2t-9.25-7L288.5-574.5q-4-3.5-4.25-8.5t4.25-9.5q4.5-4.5 9-4.5t9 4.5L480-419l173.5-173.5q3.5-3.5 8.5-4t9.5 4q4.5 4.5 4.75 9t-4.25 9L500.5-403q-5 5-9.75 7T480-394Z'/%3E%3C/svg%3E");
+				}
+				html,
+				body,
+				.grid-row:hover {
+					background-color: var(--bg-sidebar);
+				}
+				.tab:hover,
+				.tab.selected,
+				.content {
+					background-color: var(--bg);
+					scrollbar-color: var(--border-sidebar) var(--bg);
+				}
+				button {
+					background-color: var(--bg);
+					border: 1px solid var(--border-sidebar-hover);
+				}
+				button:hover {
+					border-color: var(--border-sidebar);
+				}
+				button.primary {
+					border: none;
+				}
+
+				.update-stage::before {
+					background-image: url('../icons/light/status_done.svg');
+				}
+				.stage-installing::before,
+				.stage-checking::before {
+					background-image: url('../icons/light/status_waiting.svg');
+				}
+				.stage-available::before {
+					background-image: url('../icons/light/status_important.svg');
+				}
+				.stage-downloading::before {
+					background-image: url('../icons/light/status_loading.svg');
+				}
+				.stage-error::before {
+					background-image: url('../icons/light/status_error.svg');
+				}
+
+				.stage-progress {
+					background-image: linear-gradient(to bottom, var(--bg-selected), var(--bg));
+					--animated-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="20" preserveAspectRatio="xMidYMid"><defs><linearGradient id="b" gradientTransform="rotate(90)"><stop offset="0" stop-color="%2300B0FF" /><stop offset="1" stop-color="%230091EA" /></linearGradient><pattern id="z" patternUnits="userSpaceOnUse" width="100" height="100"><g transform="translate(0)"><rect fill="url(%23b)" width="20" height="20" x="-20" /><rect fill="url(%23b)" width="20" height="20" x="20" /><animateTransform attributeName="transform" type="translate" values="0 0;40 0" keyTimes="0;1" repeatCount="indefinite" dur="1s"/></g></pattern></defs><rect width="40" height="20" fill="url(%23z)" /></svg>');
+				}
+				.stage-progress::-webkit-progress-value {
+					background-image:
+						radial-gradient(ellipse, #ffffff38, transparent 80%), var(--animated-bg),
+						linear-gradient(to top, #0091ead0, #00b0ffd0);
+					box-shadow: 0 2px 5px var(--bg-selected);
+				}
+			}
+
+			.hidden {
+				display: none;
+			}
+		</style>
+	</head>
+	<body>
+		<template id="option-checkbox">
+			<div class="grid-row">
+				<div class="option">
+					<label for="option-id">Option Name</label>
+				</div>
+				<div class="option-control">
+					<input type="checkbox" id="option-id" />
+				</div>
+			</div>
+		</template>
+		<template id="option-select">
+			<div class="grid-row">
+				<div class="option">
+					<label for="select-id">Select Name</label>
+				</div>
+				<div class="option-control">
+					<select id="select-id"></select>
+				</div>
+			</div>
+		</template>
+		<template id="option-group">
+			<h1 class="option-group">Group Name</h1>
+			<div class="grid"></div>
+		</template>
+
+		<div class="container">
+			<div class="tabgroup">
+				<a class="tab" id="options" href="#options" target="_self">
+					<span class="indicator hidden">●</span>
+					<span class="tab-title">Options</span>
+				</a>
+				<a class="tab" id="updates" href="#updates" target="_self">
+					<span class="indicator hidden">●</span>
+					<span class="tab-title">Updates</span>
+				</a>
+				<a class="tab" id="about" href="#about" target="_self">
+					<span class="indicator hidden">●</span>
+					<span class="tab-title">About</span>
+				</a>
+			</div>
+			<div class="content">
+				<div class="tab-panel options" data-for="options"></div>
+				<div class="tab-panel updates" data-for="updates">
+					<div class="update-status">
+						<div class="status-row">
+							<div class="status-label">Last checked:</div>
+							<div class="status-value" id="status-date"></div>
+						</div>
+						<div class="status-row">
+							<div class="status-label">Available version:</div>
+							<div class="status-value" id="status-available"></div>
+						</div>
+						<div class="status-row">
+							<div class="status-label">Your version:</div>
+							<div class="status-value" id="status-local"></div>
+						</div>
+					</div>
+
+					<div class="update-stage stage-latest hidden">
+						<p class="stage-label">You are using latest version</p>
+						<button class="align-end" role="button" id="update-manually">Check For Updates Manually</button>
+					</div>
+
+					<div class="update-stage stage-checking hidden">
+						<p class="stage-label">Checking update...</p>
+					</div>
+
+					<div class="update-stage stage-available hidden">
+						<p class="stage-label">New version is available!</p>
+						<button class="align-end" role="button" id="update-download">Download and Install</button>
+					</div>
+
+					<div class="update-stage stage-downloading hidden">
+						<p class="stage-label">Downloading update...</p>
+						<progress class="stage-progress" id="update-progress" value="0" max="100"></progress>
+						<div class="stage-progress-info">
+							<div class="stage-progress-info-cell">
+								<span id="update-percent"></span>
+								(<span id="update-downloaded"></span> / <span id="update-total"></span>)
+							</div>
+							<div class="stage-progress-info-cell">
+								<span id="update-speed"></span>
+							</div>
+						</div>
+					</div>
+
+					<div class="update-stage stage-ready hidden">
+						<p class="stage-label">New version is ready to install</p>
+						<button class="align-end" role="button" id="update-install">Restart And Install</button>
+					</div>
+
+					<div class="update-stage stage-installing hidden">
+						<p class="stage-label">Installing update...</p>
+					</div>
+
+					<div class="update-stage stage-installed hidden">
+						<p class="stage-label">New version is installed. It will be applied on next restart.</p>
+					</div>
+
+					<div class="update-stage stage-error hidden">
+						<p class="stage-label">An error occurred while updating</p>
+						<pre class="error-message" id="update-error"></pre>
+						<div>Restart app and try to update later.</div>
+					</div>
+
+					<span class="subheader">Changelog:</span>
+					<div class="changelog" id="changelog">
+						<span class="spinner"></span>
+					</div>
+				</div>
+				<div class="tab-panel about" data-for="about">
+					<img src="../logo.svg" alt="Notion Electron" class="logo" />
+					<h1 class="about-name">Notion Electron</h1>
+					<p class="about-text about-version">Version: <span id="version">0.0.0</span></p>
+					<p class="about-text" id="description">Unofficial Notion client</p>
+					<p class="about-text">Developed by <span id="author">Artem Nechunaev</span></p>
+					<p class="about-text">License: <span id="license">MIT</span></p>
+					<p class="about-text">
+						Source code:
+						<a href="https://github.com/anechunaev/notion-electron" target="_blank" id="source"
+							>github.com/anechunaev/notion-electron</a
+						>
+					</p>
+				</div>
+			</div>
+			<div class="footer">
+				<button class="button" role="button" id="cancel">Cancel</button>
+				<button class="button primary" role="button" id="restart">Save and Restart</button>
+			</div>
+		</div>
+
+		<script>
+			document.addEventListener('DOMContentLoaded', () => {
+				let currentTab = null;
+				let changelog = null;
+
+				const cancel = document.getElementById('cancel');
+				const restart = document.getElementById('restart');
+				const tabs = Array.from(document.querySelectorAll('.tab'));
+				const tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+				const templates = {
+					checkbox: document.getElementById('option-checkbox'),
+					select: document.getElementById('option-select'),
+					group: document.getElementById('option-group'),
+				};
+				const stageLatest = document.querySelector('.stage-latest');
+				const stageChecking = document.querySelector('.stage-checking');
+				const stageAvailable = document.querySelector('.stage-available');
+				const stageDownloading = document.querySelector('.stage-downloading');
+				const stageReady = document.querySelector('.stage-ready');
+				const stageInstalling = document.querySelector('.stage-installing');
+				const stageInstalled = document.querySelector('.stage-installed');
+				const stageError = document.querySelector('.stage-error');
+				const statusDate = document.getElementById('status-date');
+				const statusAvailable = document.getElementById('status-available');
+				const statusLocal = document.getElementById('status-local');
+				const updateManually = document.getElementById('update-manually');
+				const updateDownload = document.getElementById('update-download');
+				const updateProgress = document.getElementById('update-progress');
+				const updatePercentage = document.getElementById('update-percent');
+				const updateDownloaded = document.getElementById('update-downloaded');
+				const updateTotal = document.getElementById('update-total');
+				const updateSpeed = document.getElementById('update-speed');
+				const updateInstall = document.getElementById('update-install');
+				const updateError = document.getElementById('update-error');
+				const updateStages = [
+					stageLatest,
+					stageChecking,
+					stageAvailable,
+					stageDownloading,
+					stageReady,
+					stageInstalling,
+					stageInstalled,
+					stageError,
+				];
+				const changelogElement = document.getElementById('changelog');
+
+				function selectTab(tabId) {
+					if (tabId === currentTab) return;
+					currentTab = tabId;
+
+					tabs.forEach((t) => {
+						t.classList.toggle('selected', t.id === currentTab);
+					});
+					tabPanels.forEach((panel) => {
+						panel.classList.toggle('hidden', panel.dataset.for !== currentTab);
+					});
+
+					if (tabId === 'updates' && !changelog) {
+						window.notionElectronAPI.requestChangelog();
+					}
+				}
+
+				function toggleIndicator(tabId, value) {
+					const tab = tabs.find((t) => t.id === tabId);
+					if (!tab) return;
+					const indicator = tab.querySelector('.indicator');
+					if (!indicator) return;
+					if (typeof value === 'undefined') {
+						value = !indicator.classList.contains('hidden');
+					}
+					indicator.classList.toggle('hidden', !value);
+				}
+
+				tabs.forEach((tab) => {
+					tab.addEventListener('click', () => {
+						selectTab(tab.id);
+					});
+				});
+
+				const hash = window.location.hash.slice(1);
+				if (hash) {
+					selectTab(hash);
+				} else {
+					window.location.hash = tabs[0].id;
+					selectTab(tabs[0].id);
+				}
+
+				window.notionElectronAPI.getAppMetadata();
+				window.notionElectronAPI.getOptions();
+				window.notionElectronAPI.requestUpdateStatus();
+
+				window.notionElectronAPI.subscribeOnOptions((config) => {
+					const optionsPanel = document.querySelector('.tab-panel.options');
+					optionsPanel.innerHTML = '';
+					const options = Object.entries(config.options).map(([id, option]) => {
+						return {
+							id,
+							...option,
+						};
+					});
+					const groups = Object.entries(config.groups).reduce((acc, [id, groupName]) => {
+						acc[id] = {
+							id,
+							name: groupName,
+							el: document.importNode(templates.group.content, true),
+							options: [],
+						};
+						acc[id].el.querySelector('h1').textContent = groupName;
+						acc[id].grid = acc[id].el.querySelector('.grid');
+						return acc;
+					}, {});
+					groups.nogroup = {
+						id: 'nogroup',
+						el: document.importNode(templates.group.content, true),
+						options: [],
+					};
+					groups.nogroup.el.querySelector('h1').textContent = 'Other Options';
+					groups.nogroup.grid = groups.nogroup.el.querySelector('.grid');
+
+					options.forEach((option) => {
+						const template = templates[option.value.type];
+						if (!template) return;
+						const clone = document.importNode(template.content, true);
+						const label = clone.querySelector('label');
+						const input = clone.querySelector('input, select');
+						label.textContent = option.name;
+						label.htmlFor = option.id;
+						input.id = option.id;
+						input.name = option.id;
+						if (option.value.type === 'select') {
+							const select = input;
+							Object.entries(option.value.options).forEach(([optionValue, optionName]) => {
+								const option = document.createElement('option');
+								option.value = optionValue;
+								option.textContent = optionName;
+								select.appendChild(option);
+							});
+							select.value = option.value.data ?? option.value.default;
+						}
+						if (option.value.type === 'checkbox') {
+							input.checked = option.value.data ? 'on' : '';
+						}
+						input.addEventListener('change', (e) => {
+							if (option.value.type === 'checkbox') {
+								window.notionElectronAPI.setOption(option.id, e.currentTarget.checked);
+							} else {
+								window.notionElectronAPI.setOption(option.id, e.target.value);
+							}
+						});
+						groups[option.group ?? 'nogroup'].grid.appendChild(clone);
+					});
+					optionsPanel.append(...Object.values(groups).map((group) => group.el));
+
+					const autoUpdateCheckbox = document.getElementById('disable-update-functionality');
+					const autoUpdateDepIds = [
+						'update-check-interval',
+						'update-auto-download',
+						'update-auto-install',
+						'update-notification',
+					];
+
+					function setUpdateOptionsDisabled(disabled) {
+						autoUpdateDepIds.forEach((id) => {
+							const el = document.getElementById(id);
+							if (!el) return;
+							el.closest('.grid-row')?.classList.toggle('disabled', disabled);
+							el.disabled = disabled;
+						});
+						[updateManually, updateDownload, updateInstall].forEach((btn) => {
+							if (!btn) return;
+							btn.disabled = disabled;
+						});
+						if (updateManually) {
+							updateManually.title = disabled ? 'Update functionality is disabled, see Options' : '';
+						}
+					}
+
+					if (autoUpdateCheckbox) {
+						setUpdateOptionsDisabled(autoUpdateCheckbox.checked);
+						autoUpdateCheckbox.addEventListener('change', (e) => {
+							setUpdateOptionsDisabled(e.currentTarget.checked);
+						});
+					}
+				});
+				window.notionElectronAPI.subscribeOnTabChange((tabId) => {
+					window.location.hash = tabId;
+					selectTab(tabId);
+				});
+				window.notionElectronAPI.subscribeOnAppMetadata((metadata) => {
+					document.getElementById('version').textContent = metadata.version;
+					document.getElementById('description').textContent = metadata.description;
+					document.getElementById('author').textContent = metadata.author;
+					document.getElementById('license').textContent = metadata.license;
+				});
+				window.notionElectronAPI.subscribeOnUpdateStatusChange((data) => {
+					const {
+						stage,
+						percentage,
+						downloaded,
+						total,
+						speed,
+						error,
+						lastChecked,
+						lastCheckedFormatted,
+						availableVersion,
+						localVersion,
+					} = data;
+					updateStages.forEach((s) => s.classList.add('hidden'));
+					toggleIndicator('updates', false);
+					switch (stage) {
+						case 'latest':
+							stageLatest.classList.remove('hidden');
+							break;
+						case 'checking':
+							stageChecking.classList.remove('hidden');
+							break;
+						case 'available':
+							toggleIndicator('updates', true);
+							stageAvailable.classList.remove('hidden');
+							break;
+						case 'downloading':
+							stageDownloading.classList.remove('hidden');
+							updatePercentage.textContent = `${percentage}%`;
+							updateProgress.value = percentage;
+							updateDownloaded.textContent = downloaded;
+							updateTotal.textContent = total;
+							updateSpeed.textContent = speed;
+							break;
+						case 'ready':
+							stageReady.classList.remove('hidden');
+							break;
+						case 'installing':
+							stageInstalling.classList.remove('hidden');
+							break;
+						case 'installed':
+							stageInstalled.classList.remove('hidden');
+							break;
+						case 'error':
+							stageError.classList.remove('hidden');
+							updateError.textContent = error;
+							break;
+					}
+					statusDate.textContent = lastCheckedFormatted;
+					statusAvailable.textContent = availableVersion;
+					statusLocal.textContent = localVersion;
+				});
+				window.notionElectronAPI.subscribeOnUpdateChangelog((html) => {
+					changelog = html;
+
+					if (changelogElement) {
+						changelogElement.innerHTML = changelog;
+					}
+				});
+
+				restart.addEventListener('click', () => {
+					window.notionElectronAPI.restartApp();
+				});
+				cancel.addEventListener('click', () => {
+					window.notionElectronAPI.closeWindow();
+				});
+				updateManually.addEventListener('click', () => {
+					window.notionElectronAPI.checkUpdateForced();
+				});
+				updateDownload.addEventListener('click', () => {
+					window.notionElectronAPI.downloadUpdate();
+				});
+				updateInstall.addEventListener('click', () => {
+					window.notionElectronAPI.installUpdate();
+				});
 			});
-			groups[option.group ?? 'nogroup'].grid.appendChild(clone);
-		});
-		optionsPanel.append(...Object.values(groups).map(group => group.el));
-	});
-	window.notionElectronAPI.subscribeOnTabChange((tabId) => {
-		window.location.hash = tabId;
-		selectTab(tabId);
-	});
-	window.notionElectronAPI.subscribeOnAppMetadata((metadata) => {
-		document.getElementById('version').textContent = metadata.version;
-		document.getElementById('description').textContent = metadata.description;
-		document.getElementById('author').textContent = metadata.author;
-		document.getElementById('license').textContent = metadata.license;
-	});
-	window.notionElectronAPI.subscribeOnUpdateStatusChange(data => {
-		const {
-			stage,
-			percentage,
-			downloaded,
-			total,
-			speed,
-			error,
-			lastChecked,
-			lastCheckedFormatted,
-			availableVersion,
-			localVersion,
-		} = data;
-		updateStages.forEach(s => s.classList.add('hidden'));
-		toggleIndicator('updates', false);
-		switch(stage) {
-			case 'latest':
-				stageLatest.classList.remove('hidden');
-				break;
-			case 'checking':
-				stageChecking.classList.remove('hidden');
-				break;
-			case 'available':
-				toggleIndicator('updates', true);
-				stageAvailable.classList.remove('hidden');
-				break;
-			case 'downloading':
-				stageDownloading.classList.remove('hidden');
-				updatePercentage.textContent = `${percentage}%`;
-				updateProgress.value = percentage;
-				updateDownloaded.textContent = downloaded;
-				updateTotal.textContent = total;
-				updateSpeed.textContent = speed;
-				break;
-			case 'ready':
-				stageReady.classList.remove('hidden');
-				break;
-			case 'installing':
-				stageInstalling.classList.remove('hidden');
-				break;
-			case 'installed':
-				stageInstalled.classList.remove('hidden');
-				break;
-			case 'error':
-				stageError.classList.remove('hidden');
-				updateError.textContent = error;
-				break;
-		}
-		statusDate.textContent = lastCheckedFormatted;
-		statusAvailable.textContent = availableVersion;
-		statusLocal.textContent = localVersion;
-	});
-	window.notionElectronAPI.subscribeOnUpdateChangelog((html) => {
-		changelog = html;
-
-		if (changelogElement) {
-			changelogElement.innerHTML = changelog;
-		}
-	});
-
-	restart.addEventListener('click', () => {
-		window.notionElectronAPI.restartApp();
-	});
-	cancel.addEventListener('click', () => {
-		window.notionElectronAPI.closeWindow();
-	});
-	updateManually.addEventListener('click', () => {
-		window.notionElectronAPI.checkUpdateForced();
-	});
-	updateDownload.addEventListener('click', () => {
-		window.notionElectronAPI.downloadUpdate();
-	});
-	updateInstall.addEventListener('click', () => {
-		window.notionElectronAPI.installUpdate();
-	});
-});
-	</script>
-</body>
+		</script>
+	</body>
 </html>

--- a/index.mjs
+++ b/index.mjs
@@ -27,8 +27,13 @@ const LIGHT_THEME_BACKGROUND = '#f8f8f7';
 let mainWindow = null;
 const store = new Store();
 
-if (process.env.XDG_SESSION_DESKTOP.toLowerCase() === 'gnome' && !store.get('hide-to-tray', true)) {
-	store.set('hide-to-tray', false);
+if (process.env.XDG_SESSION_DESKTOP?.toLowerCase() === 'gnome') {
+	if (!store.has('hide-to-tray')) {
+		store.set('hide-to-tray', false);
+	}
+	if (!store.has('hide-window-on-close')) {
+		store.set('hide-window-on-close', false);
+	}
 }
 
 if (!app.requestSingleInstanceLock()) {
@@ -128,7 +133,7 @@ if (!app.requestSingleInstanceLock()) {
 
 				const optionsConfig = JSON.parse(readFileSync(path.join(__dirname, './options.json'), 'utf8'));
 				// @todo: make possible to configure default values when initialize OptionsService
-				if (process.env.XDG_SESSION_DESKTOP.toLowerCase() === 'gnome') {
+				if (process.env.XDG_SESSION_DESKTOP?.toLowerCase() === 'gnome') {
 					optionsConfig.options['hide-to-tray'].value.default = false;
 					optionsConfig.options['hide-window-on-close'].value.default = false;
 				}
@@ -195,7 +200,7 @@ if (!app.requestSingleInstanceLock()) {
 					});
 
 					mainWindow.on('minimize', function mainWindowMinimize(event) {
-						const hideToTray = store.get('hide-to-tray', true);
+						const hideToTray = store.get('hide-to-tray', optionsService.getOption('hide-to-tray').default);
 
 						if (hideToTray) {
 							event.preventDefault();
@@ -204,7 +209,10 @@ if (!app.requestSingleInstanceLock()) {
 					});
 
 					mainWindow.on('close', function mainWindowClose(event) {
-						const hideOnClose = store.get('hide-window-on-close', true);
+						const hideOnClose = store.get(
+							'hide-window-on-close',
+							optionsService.getOption('hide-window-on-close').default,
+						);
 
 						if (!app.isQuiting && hideOnClose) {
 							event.preventDefault();

--- a/index.mjs
+++ b/index.mjs
@@ -54,7 +54,7 @@ if (!app.requestSingleInstanceLock()) {
 	const enableSpellcheck = process.argv.includes('--disable-spellcheck')
 		? false
 		: store.get('general-enable-spellcheck', false);
-	const enableAutoUpdate = process.argv.includes('--disable-auto-update')
+	const enableAutoUpdate = process.argv.includes('--disable-update-functionality')
 		? false
 		: !store.get('disable-update-functionality', false);
 

--- a/index.mjs
+++ b/index.mjs
@@ -56,7 +56,7 @@ if (!app.requestSingleInstanceLock()) {
 		: store.get('general-enable-spellcheck', false);
 	const enableAutoUpdate = process.argv.includes('--disable-auto-update')
 		? false
-		: store.get('general-enable-auto-update', true);
+		: !store.get('disable-update-functionality', false);
 
 	let themeProxyPromise = Promise.resolve();
 	let dBusMonitorDisconnect = () => {};

--- a/notion-electron.desktop
+++ b/notion-electron.desktop
@@ -15,9 +15,9 @@ Name=Options
 Exec=dbus-send --session --type=signal --dest=io.github.anechunaev.NotionElectron /io/github/anechunaev/NotionElectron io.github.anechunaev.NotionElectron.Options
 
 [Desktop Action Updates]
-Name=Preferences
+Name=Updates
 Exec=dbus-send --session --type=signal --dest=io.github.anechunaev.NotionElectron /io/github/anechunaev/NotionElectron io.github.anechunaev.NotionElectron.Updates
 
 [Desktop Action About]
-Name=Preferences
+Name=About
 Exec=dbus-send --session --type=signal --dest=io.github.anechunaev.NotionElectron /io/github/anechunaev/NotionElectron io.github.anechunaev.NotionElectron.About

--- a/options.json
+++ b/options.json
@@ -36,12 +36,12 @@
 				"default": true
 			}
 		},
-		"general-enable-auto-update": {
-			"group": "g1",
-			"name": "Enable Auto Update (for AppImage only)",
+		"disable-update-functionality": {
+			"group": "g3",
+			"name": "Disable Update Functionality",
 			"value": {
 				"type": "checkbox",
-				"default": true
+				"default": false
 			}
 		},
 		"tabs-show-calendar": {


### PR DESCRIPTION
Hello @anechunaev ,
  
  I now have a good overview of the changes that benefit notion-electron. I understand what the D-Bus functionality does and what you were trying to achieve. I set up a local development
  environment to be able to test all the GNOME-specific functionality.

  The GNOME quick actions now show up when right-clicking the application icon in the GNOME dock. I found out that I had not packaged the application correctly for Nix, I had overwritten
  your desktop file and therefore ignored the D-Bus actions, which are important for correct GNOME handling. I have since updated my Nix package derivation and implemented some fixes for
  correct GNOME behaviour.

  When using the Quit option via the GNOME dock, the application did not quit correctly because the default behaviour logic for GNOME was faulty. I have tested both fixes on GNOME: the X
  button now closes the app correctly, and the Quit option via the GNOME dock works as well.

  We could consider moving DE-specific logic into its own handler where the rules are applied based on the XDG_SESSION_DESKTOP variable.

  There is currently a small known issue: if notion-electron is not already running and one of the GNOME dock actions (Options, Updates, About) is triggered, the action silently fails
  because D-Bus signals require the destination to already be registered. Just wanted to flag it.

  The Hide GUI button behaviour does not kill the application for me as described in #82  and instead just hides/minimized notion-electon (I am running GNOME 50.1).
  
  The Changes in options.html are mostly formatting changes and the handling of the update functionality and settings when updates are disabled as a whole.

BR