### PR TITLE
Refactor OptionsService to centralize config logic and enforce source precedence

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -26,8 +26,9 @@ const LIGHT_THEME_BACKGROUND = '#f8f8f7';
 
 let mainWindow = null;
 const store = new Store();
+const mainBus = new EventEmitter();
 const optionsConfig = JSON.parse(readFileSync(path.join(__dirname, './options.json'), 'utf8'));
-const optionsService = new OptionsService(store, optionsConfig);
+const optionsService = new OptionsService(store, optionsConfig, mainBus);
 
 if (!app.requestSingleInstanceLock()) {
 	app.quit();
@@ -80,9 +81,6 @@ if (!app.requestSingleInstanceLock()) {
 		.finally(() => {
 			Promise.all([themeProxyPromise, app.whenReady()]).then(([dBusColorScheme]) => {
 				Menu.setApplicationMenu(null);
-
-				const mainBus = new EventEmitter();
-
 				nativeTheme.themeSource = optionsService.getOption('general-theme');
 				let bgColor = LIGHT_THEME_BACKGROUND;
 				if (optionsService.getOption('general-theme') === 'system') {

--- a/index.mjs
+++ b/index.mjs
@@ -26,15 +26,8 @@ const LIGHT_THEME_BACKGROUND = '#f8f8f7';
 
 let mainWindow = null;
 const store = new Store();
-
-if (process.env.XDG_SESSION_DESKTOP?.toLowerCase() === 'gnome') {
-	if (!store.has('hide-to-tray')) {
-		store.set('hide-to-tray', false);
-	}
-	if (!store.has('hide-window-on-close')) {
-		store.set('hide-window-on-close', false);
-	}
-}
+const optionsConfig = JSON.parse(readFileSync(path.join(__dirname, './options.json'), 'utf8'));
+const optionsService = new OptionsService(store, optionsConfig);
 
 if (!app.requestSingleInstanceLock()) {
 	app.quit();
@@ -47,16 +40,6 @@ if (!app.requestSingleInstanceLock()) {
 			mainWindow.focus();
 		}
 	});
-
-	const showOnStartup = process.argv.includes('--hide-on-startup')
-		? false
-		: store.get('general-show-window-on-start', true);
-	const enableSpellcheck = process.argv.includes('--disable-spellcheck')
-		? false
-		: store.get('general-enable-spellcheck', false);
-	const enableAutoUpdate = process.argv.includes('--disable-update-functionality')
-		? false
-		: !store.get('disable-update-functionality', false);
 
 	let themeProxyPromise = Promise.resolve();
 	let dBusMonitorDisconnect = () => {};
@@ -97,16 +80,19 @@ if (!app.requestSingleInstanceLock()) {
 		.finally(() => {
 			Promise.all([themeProxyPromise, app.whenReady()]).then(([dBusColorScheme]) => {
 				Menu.setApplicationMenu(null);
-				nativeTheme.themeSource = store.get('general-theme', 'system');
+
+				const mainBus = new EventEmitter();
+
+				nativeTheme.themeSource = optionsService.getOption('general-theme');
 				let bgColor = LIGHT_THEME_BACKGROUND;
-				if (store.get('general-theme', 'system') === 'system') {
+				if (optionsService.getOption('general-theme') === 'system') {
 					bgColor =
 						(dBusColorScheme?.args[0][1][1] ?? nativeTheme.shouldUseDarkColors)
 							? DARK_THEME_BACKGROUND
 							: LIGHT_THEME_BACKGROUND;
 				} else {
 					bgColor =
-						store.get('general-theme', 'system') === 'dark'
+						optionsService.getOption('general-theme') === 'dark'
 							? DARK_THEME_BACKGROUND
 							: LIGHT_THEME_BACKGROUND;
 				}
@@ -119,9 +105,9 @@ if (!app.requestSingleInstanceLock()) {
 					height: screen.getPrimaryDisplay().workAreaSize.height * 0.8,
 					titleBarStyle: 'hidden',
 					icon: path.join(__dirname, './assets/icons/desktop.png'),
-					show: showOnStartup,
+					show: optionsService.getOption('general-show-window-on-start'),
 					webPreferences: {
-						spellcheck: enableSpellcheck,
+						spellcheck: optionsService.getOption('general-enable-spellcheck'),
 					},
 					titleBarOverlay: {
 						color: bgColor,
@@ -131,14 +117,6 @@ if (!app.requestSingleInstanceLock()) {
 					backgroundColor: bgColor,
 				});
 
-				const optionsConfig = JSON.parse(readFileSync(path.join(__dirname, './options.json'), 'utf8'));
-				// @todo: make possible to configure default values when initialize OptionsService
-				if (process.env.XDG_SESSION_DESKTOP?.toLowerCase() === 'gnome') {
-					optionsConfig.options['hide-to-tray'].value.default = false;
-					optionsConfig.options['hide-window-on-close'].value.default = false;
-				}
-				const mainBus = new EventEmitter();
-				const optionsService = new OptionsService(store, optionsConfig);
 				const tabService = new TabService(mainWindow, optionsService, store, mainBus);
 				const windowPositionService = new WindowPositionService(mainWindow, store);
 
@@ -174,7 +152,7 @@ if (!app.requestSingleInstanceLock()) {
 						notificationService,
 						changelogService,
 						store,
-						enableAutoUpdate,
+						optionsService,
 					);
 					const trayService = new TrayService(mainWindow, optionsWindow);
 					const contextMenuService = new ContextMenuService(mainWindow, tabService, mainBus);
@@ -200,21 +178,14 @@ if (!app.requestSingleInstanceLock()) {
 					});
 
 					mainWindow.on('minimize', function mainWindowMinimize(event) {
-						const hideToTray = store.get('hide-to-tray', optionsService.getOption('hide-to-tray').default);
-
-						if (hideToTray) {
+						if (optionsService.getOption('hide-to-tray')) {
 							event.preventDefault();
 							mainWindow.hide();
 						}
 					});
 
 					mainWindow.on('close', function mainWindowClose(event) {
-						const hideOnClose = store.get(
-							'hide-window-on-close',
-							optionsService.getOption('hide-window-on-close').default,
-						);
-
-						if (!app.isQuiting && hideOnClose) {
+						if (!app.isQuiting && optionsService.getOption('hide-window-on-close')) {
 							event.preventDefault();
 							mainWindow.hide();
 							return false;
@@ -229,14 +200,12 @@ if (!app.requestSingleInstanceLock()) {
 						process.exit(0);
 					});
 				}, 1); // Guaranteed to run on next tick despite engine optimizations
-
 				windowPositionService.restorePosition();
 			});
 		});
 
 	app.on('window-all-closed', (event) => {
-		const hideOnClose = store.get('hide-window-on-close', true);
-		if (hideOnClose) {
+		if (optionsService.getOption('hide-window-on-close')) {
 			event.preventDefault();
 		} else {
 			app.quit();

--- a/services/options.mjs
+++ b/services/options.mjs
@@ -11,6 +11,7 @@ class OptionsService {
 	#store = null;
 	#cliOverrides = {};
 	#envDefaults = {};
+	#mainBus = null;
 
 	static #DE_PRESETS = {
 		gnome: {
@@ -24,10 +25,10 @@ class OptionsService {
 		return de && de in OptionsService.#DE_PRESETS ? { ...OptionsService.#DE_PRESETS[de] } : {};
 	}
 
-	constructor(store, config, argv = process.argv, env = process.env) {
+	constructor(store, config, mainBus, argv = process.argv, env = process.env) {
 		this.#store = store;
 		this.#config = config;
-
+		this.#mainBus = mainBus;
 		this.#envDefaults = OptionsService.#buildEnvDefaults(env);
 
 		if (argv.includes('--hide-on-startup')) this.#cliOverrides['general-show-window-on-start'] = false;
@@ -101,6 +102,11 @@ class OptionsService {
 
 	setOption(optionId, value) {
 		this.#store.set(optionId, value);
+
+		// Broadcast the change (if you added the event emitter from earlier)
+		if (this.#mainBus) {
+			this.#mainBus.emit('option-changed', optionId, value);
+		}
 	}
 
 	setPersistentOption(optionId, value) {

--- a/services/options.mjs
+++ b/services/options.mjs
@@ -1,7 +1,7 @@
-import { ipcMain, app, shell } from "electron";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
+import { ipcMain, app, shell } from 'electron';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -9,45 +9,64 @@ class OptionsService {
 	#options = null;
 	#config = null;
 	#store = null;
+	#cliOverrides = {};
+	#envDefaults = {};
 
-	constructor(store, config) {
+	static #DE_PRESETS = {
+		gnome: {
+			'hide-to-tray': false,
+			'hide-window-on-close': false,
+		},
+	};
+
+	static #buildEnvDefaults(env) {
+		const de = env.XDG_SESSION_DESKTOP?.toLowerCase();
+		return de && de in OptionsService.#DE_PRESETS ? { ...OptionsService.#DE_PRESETS[de] } : {};
+	}
+
+	constructor(store, config, argv = process.argv, env = process.env) {
 		this.#store = store;
 		this.#config = config;
 
-		Object.keys(this.#config.options).forEach((optionId) => {
-			this.#config.options[optionId].value.data = this.#store.get(
-				optionId,
-				this.#config.options[optionId].value.default,
-			);
+		this.#envDefaults = OptionsService.#buildEnvDefaults(env);
+
+		if (argv.includes('--hide-on-startup')) this.#cliOverrides['general-show-window-on-start'] = false;
+		if (argv.includes('--disable-spellcheck')) this.#cliOverrides['general-enable-spellcheck'] = false;
+		if (argv.includes('--disable-update-functionality')) this.#cliOverrides['disable-update-functionality'] = true;
+
+		ipcMain.on('restart', this.#restartApp.bind(this));
+
+		ipcMain.on('get-app-metadata', this.#sendAppMetadata.bind(this));
+
+		ipcMain.on('get-options', (event) => {
+			if (!this.#options) return;
+			const payload = {
+				groups: this.#config.groups,
+				options: Object.fromEntries(
+					Object.entries(this.#config.options).map(([id, opt]) => [
+						id,
+						{ ...opt, value: { ...opt.value, data: this.getPersistentOption(id) } },
+					]),
+				),
+			};
+			this.#options.webContents.send('options', payload);
 		});
 
-		ipcMain.on("restart", this.#restartApp.bind(this));
-
-		ipcMain.on("get-app-metadata", this.#sendAppMetadata.bind(this));
-
-		ipcMain.on("get-options", (event) => {
-			if (this.#options) {
-				this.#options.webContents.send("options", this.#config);
-			}
-		});
-
-		ipcMain.on("close-window", () => {
+		ipcMain.on('close-window', () => {
 			if (this.#options) {
 				this.#options.close();
 			}
 		});
 
-		ipcMain.on("set-option", (event, optionId, value) => {
-			this.setOption(optionId, value);
+		ipcMain.on('set-option', (event, optionId, value) => {
+			this.setPersistentOption(optionId, value);
 		});
 	}
 
 	#sendAppMetadata(event) {
 		if (!this.#options) return;
-		const pkg = JSON.parse(
-			readFileSync(path.join(__dirname, "../package.json"), "utf8"),
-		);
-		this.#options.webContents.send("app-metadata", {
+		const pkg = JSON.parse(readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+		this.#options.webContents.send('app-metadata', {
 			version: pkg.version,
 			author: pkg.author,
 			license: pkg.license,
@@ -65,18 +84,27 @@ class OptionsService {
 		this.#options = optionsWindow;
 		this.#options.webContents.setWindowOpenHandler(({ url }) => {
 			shell.openExternal(url);
-			return { action: "deny" };
+			return { action: 'deny' };
 		});
 	}
 
 	getOption(optionId) {
-		return this.#config.options[optionId].value;
+		if (optionId in this.#cliOverrides) return this.#cliOverrides[optionId];
+		return this.getPersistentOption(optionId);
+	}
+
+	getPersistentOption(optionId) {
+		const configDefault = this.#config.options[optionId].value.default;
+		const fallback = optionId in this.#envDefaults ? this.#envDefaults[optionId] : configDefault;
+		return this.#store.get(optionId, fallback);
 	}
 
 	setOption(optionId, value) {
-		const optionValue = this.getOption(optionId);
 		this.#store.set(optionId, value);
-		optionValue.data = value;
+	}
+
+	setPersistentOption(optionId, value) {
+		this.setOption(optionId, value);
 	}
 }
 

--- a/services/tabs.mjs
+++ b/services/tabs.mjs
@@ -1,25 +1,18 @@
-import { WebContentsView, ipcMain, shell, app } from "electron";
-import { URL, fileURLToPath } from "node:url";
-import path from "node:path";
-import { convertIcon } from "../lib/image.mjs";
-import { detectShortcut, shortcutMap } from "../lib/shortcuts/index.mjs";
-import pkg from "../package.json" with { type: "json" };
+import { WebContentsView, ipcMain, shell, app } from 'electron';
+import { URL, fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { convertIcon } from '../lib/image.mjs';
+import { detectShortcut, shortcutMap } from '../lib/shortcuts/index.mjs';
+import pkg from '../package.json' with { type: 'json' };
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const TITLEBAR_HEIGHT = 40;
-const HOME_PAGE = "https://www.notion.com/login";
-const CALENDAR_PAGE = "https://calendar.notion.so/notion-auth";
-const MAIL_PAGE = "https://mail.notion.so/notion-auth";
-const AUTH_HOSTS = [
-	"notion.so",
-	"notion.com",
-	"google.com",
-	"live.com",
-	"microsoft.com",
-	"apple.com",
-];
-const USER_AGENT = `Mozilla/5.0 (${process.env.XDG_SESSION_TYPE ?? "X11"}; Linux ${process.arch}) Notion_Еlectron/${pkg.version} Chrome/${process.versions.chrome}`;
+const HOME_PAGE = 'https://www.notion.com/login';
+const CALENDAR_PAGE = 'https://calendar.notion.so/notion-auth';
+const MAIL_PAGE = 'https://mail.notion.so/notion-auth';
+const AUTH_HOSTS = ['notion.so', 'notion.com', 'google.com', 'live.com', 'microsoft.com', 'apple.com'];
+const USER_AGENT = `Mozilla/5.0 (${process.env.XDG_SESSION_TYPE ?? 'X11'}; Linux ${process.arch}) Notion_Еlectron/${pkg.version} Chrome/${process.versions.chrome}`;
 
 class TabsService {
 	#tabViews = {};
@@ -46,11 +39,11 @@ class TabsService {
 
 		this.#titleBarView = new WebContentsView({
 			webPreferences: {
-				preload: path.join(__dirname, "../render/tab-preload.js"),
+				preload: path.join(__dirname, '../render/tab-preload.js'),
 			},
 		});
-		this.#titleBarView.webContents.loadFile("./assets/pages/titlebar.html");
-		this.#titleBarView.webContents.on("before-input-event", (event, input) => {
+		this.#titleBarView.webContents.loadFile('./assets/pages/titlebar.html');
+		this.#titleBarView.webContents.on('before-input-event', (event, input) => {
 			detectShortcut(
 				input,
 				event,
@@ -59,130 +52,113 @@ class TabsService {
 			);
 		});
 		this.#window.contentView.addChildView(this.#titleBarView);
-		this.#currentTabId = this.#store.get("tab-current", null);
+		this.#currentTabId = this.#store.get('tab-current', null);
 
-		ipcMain.on("add-tab", (event, options) => {
+		ipcMain.on('add-tab', (event, options) => {
 			this.#addTab(options);
 		});
 
-		ipcMain.on("change-tab", (event, tabId) => {
+		ipcMain.on('change-tab', (event, tabId) => {
 			this.#onChangeTab(tabId);
 		});
 
-		ipcMain.on("close-tab", (event, tabId) => {
+		ipcMain.on('close-tab', (event, tabId) => {
 			this.#onCloseTab(tabId);
 		});
 
-		ipcMain.on("set-url", (event, tabId, url) => {
+		ipcMain.on('set-url', (event, tabId, url) => {
 			this.#setTabUrl(tabId, url);
 		});
 
-		ipcMain.on("history-changed", (event, title, icon) => {
+		ipcMain.on('history-changed', (event, title, icon) => {
 			this.#onHistoryChanged(event.sender, title, icon);
 		});
 
-		ipcMain.on("history-back", (event) => {
+		ipcMain.on('history-back', (event) => {
 			this.#tabViews[this.#currentTabId].webContents.goBack();
 		});
 
-		ipcMain.on("history-forward", (event) => {
+		ipcMain.on('history-forward', (event) => {
 			this.#tabViews[this.#currentTabId].webContents.goForward();
 		});
 
-		ipcMain.on("tab-pin-toggle", (event, tabId, isPinned) => {
+		ipcMain.on('tab-pin-toggle', (event, tabId, isPinned) => {
 			this.togglePinTab(tabId, isPinned);
 		});
 
-		if (this.#options.getOption("tabs-continue-sidebar").data) {
-			ipcMain.on("sidebar-changed", (event, collapsed, width) => {
-				this.#titleBarView.webContents.send(
-					"sidebar-changed",
-					collapsed,
-					width,
-				);
+		if (this.#options.getOption('tabs-continue-sidebar')) {
+			ipcMain.on('sidebar-changed', (event, collapsed, width) => {
+				this.#titleBarView.webContents.send('sidebar-changed', collapsed, width);
 			});
 
-			ipcMain.on("sidebar-fold", (event, collapsed) => {
-				const currentViewWebContents =
-					this.#tabViews[this.#currentTabId]?.webContents;
+			ipcMain.on('sidebar-fold', (event, collapsed) => {
+				const currentViewWebContents = this.#tabViews[this.#currentTabId]?.webContents;
 				if (currentViewWebContents) {
-					currentViewWebContents.send("sidebar-fold", collapsed);
+					currentViewWebContents.send('sidebar-fold', collapsed);
 				}
 			});
 
-			ipcMain.on("sidebar-folding-stop", (event) => {
-				this.#titleBarView.webContents.send("sidebar-folding-stop");
+			ipcMain.on('sidebar-folding-stop', (event) => {
+				this.#titleBarView.webContents.send('sidebar-folding-stop');
 			});
 
-			ipcMain.on("toggle-sidebar", () => {
-				this.sendKey(
-					{ keyCode: "\\", modifiers: ["Ctrl"] },
-					50,
-					this.#tabViews[this.#currentTabId],
-				);
+			ipcMain.on('toggle-sidebar', () => {
+				this.sendKey({ keyCode: '\\', modifiers: ['Ctrl'] }, 50, this.#tabViews[this.#currentTabId]);
 			});
 
-			ipcMain.on("request-sidebar-data", () => {
-				const currentViewWebContents =
-					this.#tabViews[this.#currentTabId]?.webContents;
+			ipcMain.on('request-sidebar-data', () => {
+				const currentViewWebContents = this.#tabViews[this.#currentTabId]?.webContents;
 				if (currentViewWebContents) {
-					currentViewWebContents.send("request-sidebar-data");
+					currentViewWebContents.send('request-sidebar-data');
 				}
 			});
 		}
 
-		ipcMain.on("request-options", (event) => {
+		ipcMain.on('request-options', (event) => {
 			const options = {
 				initialTabId: this.#currentTabId,
-				sidebarContinueToTitlebar: this.#options.getOption(
-					"tabs-continue-sidebar",
-				).data,
+				sidebarContinueToTitlebar: this.#options.getOption('tabs-continue-sidebar'),
 			};
-			event.sender.send("global-options", options);
+			event.sender.send('global-options', options);
 		});
 
-		ipcMain.on("show-offline-screen", (event, { url, isLocal }) => {
+		ipcMain.on('show-offline-screen', (event, { url, isLocal }) => {
 			if (isLocal) return;
 
-			const tabId = this.getTabIds().find((id) => {
-				return this.#tabViews[id].webContents === event.sender;
-			});
+			const tabId = this.getTabIds().find((id) => this.#tabViews[id].webContents === event.sender);
 
-			event.sender.loadFile(
-				path.join(__dirname, "../assets/pages/offline.html"),
-				{
-					query: {
-						next: tabId ? this.#tabViews[tabId].webContents.getURL() : null,
-					},
+			event.sender.loadFile(path.join(__dirname, '../assets/pages/offline.html'), {
+				query: {
+					next: tabId ? this.#tabViews[tabId].webContents.getURL() : null,
 				},
-			);
+			});
 		});
 
-		ipcMain.on("titlebar-ready", () => {
-			if (this.#options.getOption("debug-open-dev-tools").data) {
-				this.#titleBarView.webContents.openDevTools({ mode: "detach" });
+		ipcMain.on('titlebar-ready', () => {
+			if (this.#options.getOption('debug-open-dev-tools')) {
+				this.#titleBarView.webContents.openDevTools({ mode: 'detach' });
 			}
 
-			if (this.#store.get("tabs-reopen-on-start", false)) {
-				this.#reopenTabs(this.#store.get("tabs", {}));
+			if (this.#options.getOption('tabs-reopen-on-start')) {
+				this.#reopenTabs(this.#store.get('tabs', {}));
 			} else {
-				this.requestTab({ url: HOME_PAGE, app: "notes" });
+				this.requestTab({ url: HOME_PAGE, app: 'notes' });
 			}
 
-			if (this.#options.getOption("tabs-show-calendar").data) {
+			if (this.#options.getOption('tabs-show-calendar')) {
 				this.requestTab({
 					url: CALENDAR_PAGE,
 					isPinned: true,
-					app: "calendar",
+					app: 'calendar',
 					skipChange: true,
 				});
 			}
 
-			if (this.#options.getOption("tabs-show-mail").data) {
+			if (this.#options.getOption('tabs-show-mail')) {
 				this.requestTab({
 					url: MAIL_PAGE,
 					isPinned: true,
-					app: "mail",
+					app: 'mail',
 					skipChange: true,
 				});
 			}
@@ -190,33 +166,33 @@ class TabsService {
 			this.#setViewSize();
 		});
 
-		ipcMain.on("run-action", (event, actionName) => {
+		ipcMain.on('run-action', (event, actionName) => {
 			this.runAction(actionName);
 		});
 
-		this.#window.on("closed", () => {
+		this.#window.on('closed', () => {
 			Object.values(this.#tabViews).forEach((view) => view.webContents.close());
 		});
 
-		this.#window.on("resize", this.#setViewSize.bind(this));
+		this.#window.on('resize', this.#setViewSize.bind(this));
 
-		app.on("before-quit", () => {
+		app.on('before-quit', () => {
 			this.#saveTabs();
 		});
 	}
 
 	#getAppFromUrl(url) {
 		const u = new URL(url);
-		if (u.pathname.startsWith("/calendarAuth")) {
-			return "calendar";
+		if (u.pathname.startsWith('/calendarAuth')) {
+			return 'calendar';
 		}
 		switch (u.hostname) {
-			case "calendar.notion.so":
-				return "calendar";
-			case "mail.notion.so":
-				return "mail";
+			case 'calendar.notion.so':
+				return 'calendar';
+			case 'mail.notion.so':
+				return 'mail';
 			default:
-				return "notes";
+				return 'notes';
 		}
 	}
 
@@ -254,15 +230,13 @@ class TabsService {
 	#addTab({ tabId, url, isPinned = false, app }) {
 		const view = new WebContentsView({
 			webPreferences: {
-				preload: path.join(__dirname, "../render/docs-preload.js"),
-				spellcheck: process.argv.includes("--disable-spellcheck")
-					? false
-					: this.#options.getOption("general-enable-spellcheck").data,
+				preload: path.join(__dirname, '../render/docs-preload.js'),
+				spellcheck: this.#options.getOption('general-enable-spellcheck'),
 			},
 		});
 
-		if (this.#options.getOption("debug-open-dev-tools").data) {
-			view.webContents.openDevTools({ mode: "detach" });
+		if (this.#options.getOption('debug-open-dev-tools')) {
+			view.webContents.openDevTools({ mode: 'detach' });
 		}
 
 		const bounds = this.#window.getContentBounds();
@@ -288,20 +262,15 @@ class TabsService {
 			return this.#tabOpenWindowHandler(url, disposition);
 		});
 
-		view.webContents.on("before-input-event", (event, input) => {
-			detectShortcut(
-				input,
-				event,
-				view.webContents,
-				this.#titleBarView.webContents,
-			);
+		view.webContents.on('before-input-event', (event, input) => {
+			detectShortcut(input, event, view.webContents, this.#titleBarView.webContents);
 		});
 
-		view.webContents.on("context-menu", (event, params) => {
-			this.#mainBus.emit("show-page-context-menu", {
+		view.webContents.on('context-menu', (event, params) => {
+			this.#mainBus.emit('show-page-context-menu', {
 				sender: view.webContents,
 				isLink: Boolean(params.linkURL),
-				isImage: params.mediaType === "image" && Boolean(params.srcURL),
+				isImage: params.mediaType === 'image' && Boolean(params.srcURL),
 				linkUrl: params.linkURL,
 				imageUrl: params.srcURL,
 				isSelection: Boolean(params.selectionText),
@@ -320,9 +289,9 @@ class TabsService {
 
 		const isAuthHost = AUTH_HOSTS.some((host) => u.hostname.includes(host));
 
-		if (isAuthHost && disposition === "new-window") {
+		if (isAuthHost && disposition === 'new-window') {
 			return {
-				action: "allow",
+				action: 'allow',
 				overrideBrowserWindowOptions: {
 					width: 520,
 					height: 760,
@@ -337,38 +306,32 @@ class TabsService {
 			};
 		}
 
-		if (u.hostname.includes("notion.com") || u.hostname.includes("notion.so")) {
-			if (
-				disposition === "new-window" ||
-				disposition === "foreground-tab" ||
-				disposition === "background-tab"
-			) {
-				this.#titleBarView.webContents.send("tab-request", {
+		if (u.hostname.includes('notion.com') || u.hostname.includes('notion.so')) {
+			if (disposition === 'new-window' || disposition === 'foreground-tab' || disposition === 'background-tab') {
+				this.#titleBarView.webContents.send('tab-request', {
 					url: u.toString(),
 				});
-				return { action: "deny" };
+				return { action: 'deny' };
 			}
 			return {
-				action: "allow",
+				action: 'allow',
 				closeWithOpener: false,
 				overrideBrowserWindowOptions: undefined,
 			};
 		}
 
 		shell.openExternal(url);
-		return { action: "deny" };
+		return { action: 'deny' };
 	}
 
 	#onChangeTab(tabId) {
 		const view = this.#tabViews[this.#currentTabId];
-		this.#titleBarView.webContents.send("tab-info", tabId, {
+		this.#titleBarView.webContents.send('tab-info', tabId, {
 			title: null,
 			icon: null,
 			documentUrl: view?.webContents?.getURL(),
 			canGoBack: Boolean(view?.webContents?.navigationHistory.canGoBack()),
-			canGoForward: Boolean(
-				view?.webContents?.navigationHistory.canGoForward(),
-			),
+			canGoForward: Boolean(view?.webContents?.navigationHistory.canGoForward()),
 		});
 		this.#setVisibleTabs(tabId);
 	}
@@ -398,38 +361,30 @@ class TabsService {
 	}
 
 	#onHistoryChanged(sender, title, icon) {
-		const tabId = Object.keys(this.#tabViews).find((tabId) => {
-			return this.#tabViews[tabId].webContents === sender;
-		});
+		const tabId = Object.keys(this.#tabViews).find((tabId) => this.#tabViews[tabId].webContents === sender);
 
 		if (tabId) {
 			const view = this.#tabViews[tabId];
 
 			if (icon) {
 				convertIcon(icon).then((convertedIcon) => {
-					this.#titleBarView.webContents.send("tab-info", tabId, {
+					this.#titleBarView.webContents.send('tab-info', tabId, {
 						title: null,
 						icon: convertedIcon,
 						documentUrl: view.webContents?.getURL(),
-						canGoBack: Boolean(
-							view?.webContents?.navigationHistory.canGoBack(),
-						),
-						canGoForward: Boolean(
-							view?.webContents?.navigationHistory.canGoForward(),
-						),
+						canGoBack: Boolean(view?.webContents?.navigationHistory.canGoBack()),
+						canGoForward: Boolean(view?.webContents?.navigationHistory.canGoForward()),
 					});
 					this.#iconMap[tabId] = convertedIcon;
 				});
 			}
 			if (title) {
-				this.#titleBarView.webContents.send("tab-info", tabId, {
+				this.#titleBarView.webContents.send('tab-info', tabId, {
 					title,
 					icon: null,
 					documentUrl: view.webContents?.getURL(),
 					canGoBack: Boolean(view?.webContents?.navigationHistory.canGoBack()),
-					canGoForward: Boolean(
-						view?.webContents?.navigationHistory.canGoForward(),
-					),
+					canGoForward: Boolean(view?.webContents?.navigationHistory.canGoForward()),
 				});
 				this.#titlesMap[tabId] = title;
 			}
@@ -438,7 +393,7 @@ class TabsService {
 
 	sendKey(entry, delay, view) {
 		if (!view) return;
-		["keyDown", "char", "keyUp"].forEach(async (type) => {
+		['keyDown', 'char', 'keyUp'].forEach(async (type) => {
 			entry.type = type;
 			view.webContents.sendInputEvent(entry);
 
@@ -459,13 +414,13 @@ class TabsService {
 	}
 
 	duplicateTab(tabId) {
-		this.#titleBarView.webContents.send("tab-request", {
+		this.#titleBarView.webContents.send('tab-request', {
 			url: this.#tabViews[tabId].webContents.getURL(),
 		});
 	}
 
 	requestTab(options) {
-		this.#titleBarView.webContents.send("tab-request", options);
+		this.#titleBarView.webContents.send('tab-request', options);
 	}
 
 	getTabsJSON() {
@@ -481,13 +436,13 @@ class TabsService {
 
 	#reopenTabs(tabs) {
 		Object.entries(tabs).forEach(([tabId, url]) => {
-			const isPinned = this.#store.get("tabs-pinned", {})[tabId] ?? false;
-			const apps = this.#store.get("tab-apps", {
+			const isPinned = this.#store.get('tabs-pinned', {})[tabId] ?? false;
+			const apps = this.#store.get('tab-apps', {
 				notes: [],
 				calendar: [],
 				mail: [],
 			});
-			let app = "notes";
+			let app = 'notes';
 			Object.entries(apps).forEach(([appName, tabIds]) => {
 				if (tabIds.includes(tabId)) {
 					app = appName;
@@ -498,11 +453,11 @@ class TabsService {
 	}
 
 	#saveTabs() {
-		if (this.#store.get("tabs-reopen-on-start", false)) {
-			this.#store.set("tabs", this.getTabsJSON());
-			this.#store.set("tab-current", this.#currentTabId);
-			this.#store.set("tabs-pinned", this.#pinnedMap);
-			this.#store.set("tab-apps", this.#tabAppMap);
+		if (this.#options.getOption('tabs-reopen-on-start')) {
+			this.#store.set('tabs', this.getTabsJSON());
+			this.#store.set('tab-current', this.#currentTabId);
+			this.#store.set('tabs-pinned', this.#pinnedMap);
+			this.#store.set('tab-apps', this.#tabAppMap);
 		}
 	}
 

--- a/services/tabs.mjs
+++ b/services/tabs.mjs
@@ -37,6 +37,15 @@ class TabsService {
 		this.#store = store;
 		this.#mainBus = mainBus;
 
+		this.#mainBus.on('option-changed', (optionId, value) => {
+			if (optionId === 'tabs-show-calendar' && value === false) {
+				this.#closeTabsByApp('calendar');
+			}
+			if (optionId === 'tabs-show-mail' && value === false) {
+				this.#closeTabsByApp('mail');
+			}
+		});
+
 		this.#titleBarView = new WebContentsView({
 			webPreferences: {
 				preload: path.join(__dirname, '../render/tab-preload.js'),
@@ -211,6 +220,14 @@ class TabsService {
 				width: bounds.width,
 				height: bounds.height - TITLEBAR_HEIGHT,
 			});
+		});
+	}
+
+	#closeTabsByApp(appName) {
+		const tabIds = this.#tabAppMap[appName] || [];
+		// Clone the array with [...] because #onCloseTab mutates the original array
+		[...tabIds].forEach((tabId) => {
+			this.#onCloseTab(tabId);
 		});
 	}
 

--- a/services/update.mjs
+++ b/services/update.mjs
@@ -12,6 +12,7 @@ class UpdateService extends EventEmitter {
 	#updater = electronUpdater.autoUpdater;
 	#optionsWindow = null;
 	#store = null;
+	#options = null;
 	#lastChecked = null;
 	#checkInterval = ONE_DAY_MS;
 	#availableVersion = null;
@@ -25,10 +26,11 @@ class UpdateService extends EventEmitter {
 	#notifications;
 	#changelog;
 
-	constructor(optionsWindow, notificationService, changelogService, store, enableAutoUpdate = true) {
+	constructor(optionsWindow, notificationService, changelogService, store, optionsService) {
 		super();
 		this.#optionsWindow = optionsWindow;
 		this.#store = store;
+		this.#options = optionsService;
 		this.#notifications = notificationService;
 		this.#changelog = changelogService;
 
@@ -39,7 +41,7 @@ class UpdateService extends EventEmitter {
 		this.#availableVersion = this.#store.get('update-available-version', this.#localVersion);
 		this.#lastChecked = this.#store.get('update-last-checked', ERA_START.toISOString());
 		this.#stage = this.#semverIsBigger(this.#availableVersion, this.#localVersion) ? 'available' : 'latest';
-		switch(this.#store.get('update-check-interval', 'daily')) {
+		switch(this.#options.getOption('update-check-interval')) {
 		case 'daily':
 			this.#checkInterval = ONE_DAY_MS;
 			break;
@@ -54,7 +56,7 @@ class UpdateService extends EventEmitter {
 			break;
 		}
 
-		if (enableAutoUpdate) {
+		if (!this.#options.getOption('disable-update-functionality')) {
 			this.#checkUpdate();
 			setInterval(() => {
 				this.#checkUpdate();
@@ -81,14 +83,14 @@ class UpdateService extends EventEmitter {
 			this.#store.set('update-last-checked', this.#lastChecked);
 			this.#store.set('update-available-version', this.#availableVersion);
 
-			if (this.#store.get('update-notification', false)) {
+			if (this.#options.getOption('update-notification')) {
 				this.#notifications.notify({
 					title: 'Update available',
 					body: `Version ${this.#availableVersion} is available for download.`,
 				});
 			}
 
-			if (process.env.APPIMAGE && store.get('update-auto-download', false)) {
+			if (process.env.APPIMAGE && this.#options.getOption('update-auto-download')) {
 				this.#downloadUpdate();
 			} else {
 				this.#stage = this.#semverIsBigger(this.#availableVersion, this.#localVersion) ? 'available' : 'latest';
@@ -118,7 +120,7 @@ class UpdateService extends EventEmitter {
 			this.#sendStatus();
 		});
 		this.#updater.on('update-downloaded', (info) => {
-			if (process.env.APPIMAGE && store.get('update-auto-install', false)) {
+			if (process.env.APPIMAGE && this.#options.getOption('update-auto-install')) {
 				this.#installUpdate();
 			} else {
 				this.#stage = 'ready';


### PR DESCRIPTION
@anechunaev I could not resist and implemented the changes! Currently, I am hard at work on productive procrastination instead of studying for my exam.

---

### Changes Introduced

This refactor centralizes all configuration management inside the `OptionsService` and establishes a strict precedence order: **CLI flags > GUI settings > Environment variables**.

* **Centralized Source of Truth:** Moved all handling of CLI flags and environment variables directly into the `OptionsService`.
* **API Separation (Effective vs. Persistent):** Implemented `getOption()` / `setOption()` to act on the effective value (combining all sources based on precedence) for services implementing business logic. Conversely, `getPersistentOption()` / `setPersistentOption()` act strictly on user-persisted choices, ensuring the GUI only reflects saved settings and not temporary CLI overrides.
* **Removed Direct Storage Access:** Refactored consumers throughout the application to use the new `OptionsService` API rather than accessing the underlying storage directly. *(Note: The only services that still access the store directly are those that handle internal application state and session persistence—like `WindowPositionService` or the session-saving portions of `TabsService` and `UpdateService` - rather than user-configurable settings).* Note: Feel free to suggest how we could handle these in the future or if its ok for these services to access the store directly without any wrapper.
* **Immutable Getter Pattern:** Ensured that values are no longer mutated by reference, preventing the GUI from magically changing values unexpectedly on subsequent launches.
* **DE-Specific Settings:** Handled via a simple object mapping (`optionsId: value`) that automatically gets applied on app start.

BR