### PR TITLE
fix: Fixed RPM build-id file conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,12 @@
 			},
 			"category": "Utility;Office;"
 		},
+		"rpm": {
+			"fpm": [
+				"--rpm-rpmbuild-define",
+				"_build_id_links none"
+			]
+		},
 		"snapcraft": {
 			"base": "core24",
 			"core24": {


### PR DESCRIPTION
## What changed

Disabled RPM build-id link generation by passing `_build_id_links none` through electron-builder's FPM RPM options.

## Why

The generated RPM included `/usr/lib/.build-id/*` entries. Those files can conflict with other RPM packages that also ship build-id links, such as Slack:

```text
file /usr/lib/.build-id/42/f633ec8d28e46e850ad58ffc5f831c734ab159 from install of notion-electron-2.2.2-1.x86_64 conflicts with file from package slack-4.50.136-0.1.el8.x86_64
```

This keeps the RPM from owning global build-id paths that are not needed for the application package.

## Verification

- Built the RPM with `npm run build && npx electron-builder --linux rpm`
- Confirmed the generated RPM does not include build-id entries with `rpm -qlp dist/Notion_Electron-2.2.3-x86_64.rpm | grep -F '/usr/lib/.build-id'`, which produced no output
- Upgraded locally from `notion-electron-2.2.2-1.x86_64` to the generated `2.2.3-1` RPM with `sudo dnf upgrade ./dist/Notion_Electron-2.2.3-x86_64.rpm`; the transaction completed successfully with Slack installed
- Pre-commit hook passed: `npm run typecheck` and `npm run lint`

## AI assistance disclosure

I used an AI assistant to inspect the packaging setup and draft the minimal RPM configuration change. I reviewed the change and verified the generated RPM no longer includes `/usr/lib/.build-id` entries.
