### PR TITLE
fix: Fixed new tab workspace context

### DIFF
--- a/src/main/lib/shortcuts/index.ts
+++ b/src/main/lib/shortcuts/index.ts
@@ -23,10 +23,11 @@ export function detectShortcut(
 	const accelString = accelerator.join('+');
 	const shortcut = Object.values(shortcutMap).find((s) => s.accelerator === accelString);
 	if (shortcut) {
+		event.preventDefault();
+		if (input.type !== 'keyDown') return;
 		shortcut.action({
 			pageWebContents,
 			titlebarWebContents,
 		});
-		event.preventDefault();
 	}
 }

--- a/src/main/services/tabs.ts
+++ b/src/main/services/tabs.ts
@@ -18,12 +18,24 @@ import pkg from '../../../package.json';
 export type { TabRequestOptions } from './tabs.types';
 
 const HOME_PAGE = getAppHomeUrl('notes');
+const NOTION_NOTES_HOSTS = new Set(['app.notion.com', 'www.notion.so']);
 
 const PINNED_APP_OPTIONS: Partial<Record<AppName, keyof OptionValues>> = {
 	calendar: 'tabs-show-calendar',
 	mail: 'tabs-show-mail',
 };
 const USER_AGENT = `Mozilla/5.0 (${process.env.XDG_SESSION_TYPE ?? 'X11'}; Linux ${process.arch}) Notion_Еlectron/${pkg.version} Chrome/${process.versions.chrome}`;
+
+function getKnownNotesUrl(url: string): string | undefined {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return undefined;
+	}
+	if (!NOTION_NOTES_HOSTS.has(parsed.hostname)) return undefined;
+	return parsed.pathname === '/' ? undefined : parsed.toString();
+}
 
 async function sendKey(
 	entry: { keyCode: string; modifiers?: string[] },
@@ -310,7 +322,20 @@ class TabsService implements TabReader, TabCommands {
 		this.revealTab(id, skipChange);
 	}
 
+	private getNewTabUrl(app: AppName | undefined): string {
+		if (app && app !== 'notes') return getAppHomeUrl(app);
+
+		const currentUrl = this.currentView()?.webContents.getURL();
+		if (currentUrl) {
+			const notesUrl = getKnownNotesUrl(currentUrl);
+			if (notesUrl) return notesUrl;
+		}
+
+		return HOME_PAGE;
+	}
+
 	private createTabView(tabId: string, url: string | undefined, app: AppName | undefined, isPinned: boolean): void {
+		const tabUrl = url ?? this.getNewTabUrl(app);
 		const view = new WebContentsView({
 			webPreferences: {
 				preload: resolvePreload('docs.cjs'),
@@ -325,7 +350,7 @@ class TabsService implements TabReader, TabCommands {
 		view.setBounds(this.layout.contentBounds());
 
 		view.webContents
-			.loadURL(url ?? HOME_PAGE, {
+			.loadURL(tabUrl, {
 				userAgent: USER_AGENT,
 			})
 			.then(() => {
@@ -375,7 +400,7 @@ class TabsService implements TabReader, TabCommands {
 
 		this.tabViews[tabId] = view;
 		this.pinnedMap[tabId] = isPinned;
-		this.tabApp[tabId] = app ?? getAppFromUrl(url ?? HOME_PAGE);
+		this.tabApp[tabId] = app ?? getAppFromUrl(tabUrl);
 		this.tabOrder.push(tabId);
 	}
 

--- a/src/renderer/titlebar/script.ts
+++ b/src/renderer/titlebar/script.ts
@@ -153,7 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	if (window.notionElectronAPI) {
 		if (addTabButton) {
-			addTabButton.addEventListener('click', () => window.notionElectronAPI.addTab({ url: NOTION_NOTES_HOST }));
+			addTabButton.addEventListener('click', () => window.notionElectronAPI.addTab({}));
 		}
 
 		if (historyBackButton) {
@@ -251,7 +251,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		window.notionElectronAPI.subscribeOnAction((action) => {
 			switch (action) {
 				case 'tab-add':
-					window.notionElectronAPI.addTab({ url: NOTION_NOTES_HOST });
+					window.notionElectronAPI.addTab({});
 					break;
 				case 'tab-close':
 					window.notionElectronAPI.closeCurrentTab();


### PR DESCRIPTION
## What changed

Before:
- Creating a tab from the titlebar always passed `https://app.notion.com` from the renderer.
- Notion's root app route could resolve from shared session/cache state, which could open the marketing site or a workspace from another account.
- The shortcut handler ran the action for shortcut input events before filtering to the actual key press.

Now:
- The titlebar sends a generic add-tab request, and the main tabs service resolves the URL.
- For notes tabs without an explicit URL, the main process reuses the active tab's known Notion app/page URL when it is account/workspace-specific.
- The fallback no longer scans other tabs, so it does not accidentally pick a workspace from another logged-in account.
- Shortcuts are prevented before the page can handle them and only execute on `keyDown`.

## Testing

- `npm run typecheck`
- `npm run lint` via the pre-commit hook
- Manual Linux verification with `npm start`
- Confirmed `Ctrl+T` opens a new tab in the active account's workspace instead of `notion.com` or another logged-in account's workspace
- Confirmed the `+` tab button follows the same behavior

## AI disclosure

This patch and PR description were drafted with AI assistance and reviewed and manually verified before review.
